### PR TITLE
implement stream restore for tikv side.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=br-stream#b74e38458440e5300b489d29ecf63d1ea586a0d2"
+source = "git+https://github.com/pingcap/kvproto.git?branch=br-stream#11c47a2c2f8e3c59b4cb12abd479675eaad69f3b"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/br-stream/src/lib.rs
+++ b/components/br-stream/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 #![feature(inherent_ascii_escape)]
-pub mod codec;
 pub mod config;
 mod endpoint;
 pub mod errors;

--- a/components/br-stream/src/lib.rs
+++ b/components/br-stream/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 #![feature(inherent_ascii_escape)]
-mod codec;
+pub mod codec;
 pub mod config;
 mod endpoint;
 pub mod errors;

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -44,6 +44,7 @@ use tikv_util::{
     warn,
     worker::Scheduler,
     Either,
+    codec::stream_event::EventEncoder,
 };
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
@@ -785,7 +786,7 @@ impl DataFile {
     async fn on_event(&mut self, mut kv: ApplyEvent) -> Result<usize> {
         let now = Instant::now_coarse();
         let _entry_size = kv.size();
-        let encoded = Encoder::encode_event(&kv.key, &kv.value);
+        let encoded = EventEncoder::encode_event(&kv.key, &kv.value);
         let mut size = 0;
         for slice in encoded {
             let slice = slice.as_ref();

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -40,7 +40,7 @@ use tidb_query_datatype::codec::table::decode_table_id;
 use tikv_util::{
     box_err,
     codec::stream_event::EventEncoder,
-    defer, info,
+    defer, info, error,
     time::{Instant, Limiter},
     warn,
     worker::Scheduler,

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -39,12 +39,13 @@ use slog_global::debug;
 use tidb_query_datatype::codec::table::decode_table_id;
 
 use tikv_util::{
-    box_err, defer, error, info,
+    box_err,
+    codec::stream_event::EventEncoder,
+    defer, info,
     time::{Instant, Limiter},
     warn,
     worker::Scheduler,
     Either,
-    codec::stream_event::EventEncoder,
 };
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 use crate::{
-    codec::Encoder,
     endpoint::Task,
     errors::Error,
     metadata::StreamTask,

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -219,8 +219,7 @@ impl ImportDir {
         })
     }
 
-    pub fn join(&self, meta: &SstMeta) -> Result<ImportPath> {
-        let file_name = sst_meta_to_path(meta)?;
+    pub fn get_import_path(&self, file_name: &str) -> Result<ImportPath> {
         let save_path = self.root_dir.join(&file_name);
         let temp_path = self.temp_dir.join(&file_name);
         let clone_path = self.clone_dir.join(&file_name);
@@ -229,6 +228,11 @@ impl ImportDir {
             temp: temp_path,
             clone: clone_path,
         })
+    }
+
+    pub fn join(&self, meta: &SstMeta) -> Result<ImportPath> {
+        let file_name = sst_meta_to_path(meta)?;
+        self.get_import_path(file_name.to_str().unwrap())
     }
 
     pub fn create(

--- a/components/sst_importer/src/metrics.rs
+++ b/components/sst_importer/src/metrics.rs
@@ -83,4 +83,12 @@ lazy_static! {
         &["type", "error"]
     )
     .unwrap();
+    pub static ref IMPORTER_APPLY_DURATION: HistogramVec = register_histogram_vec!(
+        "tikv_import_apply_duration",
+        "Bucketed histogram of importer apply duration",
+        &["type"],
+        // Start from 10ms.
+        exponential_buckets(0.01, 2.0, 20).unwrap()
+    )
+    .unwrap();
 }

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -127,6 +127,33 @@ impl SSTImporter {
         self.dir.exist(meta).unwrap_or(false)
     }
 
+    // Donwloads and Apply an KV file from an external storage.
+    pub fn apply<E: KvEngine>(
+        &self,
+        backend: &StorageBackend,
+        name: &str,
+        rewrite_rule: &RewriteRule,
+        speed_limiter: Limiter,
+        encoder: Encoder,
+        engine: E,
+    ) -> Result<Option<Range>> {
+        debug!("download start";
+            "url" => ?backend,
+            "name" => name,
+            "rewrite_rule" => ?rewrite_rule,
+        );
+        match self.do_download_and_apply::<E>(backend, name, rewrite_rule, &speed_limiter, engine) {
+            Ok(r) => {
+                info!("apply"; "name" => name, "range" => ?r);
+                Ok(r)
+            }
+            Err(e) => {
+                error!(%e; "applyfailed"; "name" => name,);
+                Err(e)
+            }
+        }
+    }
+
     // Downloads an SST file from an external storage.
     //
     // This method is blocking. It performs the following transformations before
@@ -166,7 +193,7 @@ impl SSTImporter {
             name,
             rewrite_rule,
             crypter,
-            speed_limiter,
+            &speed_limiter,
             engine,
         ) {
             Ok(r) => {
@@ -192,6 +219,89 @@ impl SSTImporter {
         self.switcher.get_mode()
     }
 
+    fn download_file_from_external_storage(
+        &self,
+        file_length: u64,
+        src_file_name: &str,
+        dst_file: std::path::PathBuf,
+        backend: &StorageBackend,
+        rewrite_rule: &RewriteRule,
+        file_crypter: Option<FileEncryptionInfo>,
+        speed_limiter: &Limiter,
+    ) -> Result<()> {
+        let start_read = Instant::now();
+        // prepare to download the file from the external_storage
+        // TODO: pass a config to support hdfs
+        let ext_storage = external_storage_export::create_storage(backend, Default::default())?;
+        let url = ext_storage.url()?.to_string();
+
+        let ext_storage: Box<dyn external_storage_export::ExternalStorage> =
+            if let Some(key_manager) = &self.key_manager {
+                Box::new(external_storage_export::EncryptedExternalStorage {
+                    key_manager: (*key_manager).clone(),
+                    storage: ext_storage,
+                }) as _
+            } else {
+                ext_storage as _
+            };
+
+        let result = ext_storage.restore(
+            src_file_name,
+            dst_file.clone(),
+            file_length,
+            &speed_limiter,
+            file_crypter,
+        );
+        IMPORTER_DOWNLOAD_BYTES.observe(file_length as _);
+        result.map_err(|e| Error::CannotReadExternalStorage {
+            url: url.to_string(),
+            name: src_file_name.to_owned(),
+            local_path: dst_file.clone(),
+            err: e,
+        })?;
+
+        OpenOptions::new()
+            .append(true)
+            .open(dst_file)?
+            .sync_data()?;
+
+        IMPORTER_DOWNLOAD_DURATION
+            .with_label_values(&["read"])
+            .observe(start_read.saturating_elapsed().as_secs_f64());
+
+        debug!("downloaded file succeed";
+            "name" => src_file_name,
+            "url"  => %url,
+        );
+        Ok(())
+    }
+
+    fn do_download_and_apply<E: KvEngine>(
+        &self,
+        backend: &StorageBackend,
+        name: &str,
+        rewrite_rule: &RewriteRule,
+        speed_limiter: &Limiter,
+        engine: E,
+    ) -> Result<Option<Range>> {
+        let path = self.dir.get_import_path(name)?;
+
+        self.download_file_from_external_storage(
+            // don't check file lengthn after download file for now.
+            0,
+            name,
+            path.temp,
+            backend,
+            rewrite_rule,
+            // don't support encrypt for now.
+            None,
+            &speed_limiter,
+        )?;
+
+        // iterator `path.temp` file and performs rewrites and apply.
+        unimplemented!();
+    }
+
     fn do_download<E: KvEngine>(
         &self,
         meta: &SstMeta,
@@ -199,73 +309,38 @@ impl SSTImporter {
         name: &str,
         rewrite_rule: &RewriteRule,
         crypter: Option<CipherInfo>,
-        speed_limiter: Limiter,
+        speed_limiter: &Limiter,
         engine: E,
     ) -> Result<Option<Range>> {
         let path = self.dir.join(meta)?;
-        let url = {
-            let start_read = Instant::now();
 
-            // prepare to download the file from the external_storage
-            // TODO: pass a config to support hdfs
-            let ext_storage = external_storage_export::create_storage(backend, Default::default())?;
-            let url = ext_storage.url()?.to_string();
+        let file_crypter = crypter.map(|c| FileEncryptionInfo {
+            method: encryption_method_to_db_encryption_method(c.cipher_type),
+            key: c.cipher_key,
+            iv: meta.cipher_iv.to_owned(),
+        });
 
-            let ext_storage: Box<dyn external_storage_export::ExternalStorage> =
-                if let Some(key_manager) = &self.key_manager {
-                    Box::new(external_storage_export::EncryptedExternalStorage {
-                        key_manager: (*key_manager).clone(),
-                        storage: ext_storage,
-                    }) as _
-                } else {
-                    ext_storage as _
-                };
-
-            let file_crypter = crypter.map(|c| FileEncryptionInfo {
-                method: encryption_method_to_db_encryption_method(c.cipher_type),
-                key: c.cipher_key,
-                iv: meta.cipher_iv.to_owned(),
-            });
-
-            let result = ext_storage.restore(
-                name,
-                path.temp.to_owned(),
-                meta.length,
-                &speed_limiter,
-                file_crypter,
-            );
-            IMPORTER_DOWNLOAD_BYTES.observe(meta.length as _);
-            result.map_err(|e| Error::CannotReadExternalStorage {
-                url: url.to_string(),
-                name: name.to_owned(),
-                local_path: path.temp.to_owned(),
-                err: e,
-            })?;
-
-            OpenOptions::new()
-                .append(true)
-                .open(&path.temp)?
-                .sync_data()?;
-
-            IMPORTER_DOWNLOAD_DURATION
-                .with_label_values(&["read"])
-                .observe(start_read.saturating_elapsed().as_secs_f64());
-
-            url
-        };
+        self.download_file_from_external_storage(
+            meta.length,
+            name,
+            path.temp.clone(),
+            backend,
+            rewrite_rule,
+            file_crypter,
+            &speed_limiter,
+        )?;
 
         // now validate the SST file.
-        let path_str = path.temp.to_str().unwrap();
         let env = get_env(self.key_manager.clone(), get_io_rate_limiter())?;
         // Use abstracted SstReader after Env is abstracted.
-        let sst_reader = RocksSstReader::open_with_env(path_str, Some(env))?;
+        let dst_file_name = path.temp.to_str().unwrap();
+        let sst_reader = RocksSstReader::open_with_env(dst_file_name, Some(env))?;
         sst_reader.verify_checksum()?;
 
         debug!("downloaded file and verified";
             "meta" => ?meta,
-            "url" => %url,
             "name" => name,
-            "path" => path_str,
+            "path" => dst_file_name,
         );
 
         // undo key rewrite so we could compare with the keys inside SST

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -336,7 +336,7 @@ impl SSTImporter {
 
         let start = Instant::now();
         loop {
-            if event_iter.valid() {
+            if !event_iter.valid() {
                 break;
             }
             event_iter.next()?;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -2,11 +2,11 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::{prelude::*, BufReader};
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::fs::File;
-use std::io::{prelude::*, BufReader};
 
 use futures::executor::ThreadPool;
 use kvproto::brpb::{CipherInfo, StorageBackend};
@@ -22,7 +22,7 @@ use engine_traits::{
 use file_system::{get_io_rate_limiter, OpenOptions};
 use kvproto::kvrpcpb::ApiVersion;
 use tikv_util::{
-    codec::stream_event::EventEncoder,
+    codec::stream_event::EventIterator,
     time::{Instant, Limiter},
 };
 use txn_types::{Key, TimeStamp, WriteRef};
@@ -138,18 +138,21 @@ impl SSTImporter {
         backend: &StorageBackend,
         name: &str,
         rewrite_rule: &RewriteRule,
+        cf: &str,
         speed_limiter: Limiter,
         engine: E,
     ) -> Result<Option<Range>> {
         debug!("apply start";
             "url" => ?backend,
             "name" => name,
+            "cf" => cf,
             "rewrite_rule" => ?rewrite_rule,
         );
         match self.do_download_and_apply::<E>(
             backend,
             name,
             rewrite_rule,
+            cf,
             &speed_limiter,
             engine,
         ) {
@@ -158,7 +161,7 @@ impl SSTImporter {
                 Ok(r)
             }
             Err(e) => {
-                error!(%e; "applyfailed"; "name" => name,);
+                error!(%e; "apply failed"; "name" => name,);
                 Err(e)
             }
         }
@@ -289,9 +292,10 @@ impl SSTImporter {
         &self,
         backend: &StorageBackend,
         name: &str,
-        _rewrite_rule: &RewriteRule,
+        rewrite_rule: &RewriteRule,
+        cf: &str,
         speed_limiter: &Limiter,
-        _engine: E,
+        engine: E,
     ) -> Result<Option<Range>> {
         let path = self.dir.get_import_path(name)?;
         self.download_file_from_external_storage(
@@ -304,17 +308,78 @@ impl SSTImporter {
             None,
             &speed_limiter,
         )?;
+        info!("download file finished {}", name);
 
         // iterator `path.temp` file and performs rewrites and apply.
         let file = File::open(path.temp)?;
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
+        let mut buffer = Vec::new();
+        reader.read_to_end(&mut buffer)?;
 
-        for line in reader.lines() {
-            let (k, v) = EventEncoder::decode_event(line?.as_bytes());
-            println!("key: {:?}, val: {:?}", k, v);
-            // engine.put_cf()
+        let mut event_iter = EventIterator::new(buffer);
+
+        let old_prefix = rewrite_rule.get_old_key_prefix();
+        let new_prefix = rewrite_rule.get_new_key_prefix();
+
+        let perform_rewrite = old_prefix != new_prefix;
+
+        // perform iteration and key rewrite.
+        let mut key = keys::data_key(new_prefix);
+        let new_prefix_data_key_len = key.len();
+        let mut smallest_key = None;
+        let mut largest_key = None;
+
+        loop {
+            match event_iter.next() {
+                Some(k) => {
+                    if perform_rewrite {
+                        let old_key = &k;
+
+                        if !old_key.starts_with(old_prefix) {
+                            return Err(Error::WrongKeyPrefix {
+                                what: "Key in file",
+                                key: old_key.to_vec(),
+                                prefix: old_prefix.to_vec(),
+                            });
+                        }
+                        key.truncate(new_prefix_data_key_len);
+                        key.extend_from_slice(&old_key[old_prefix.len()..]);
+
+                        debug!(
+                            "perform rewrite new key: {:?}, new key prefix: {:?}, old key prefix: {:?}",
+                            log_wrappers::Value::key(keys::origin_key(&key)),
+                            log_wrappers::Value::key(&new_prefix),
+                            log_wrappers::Value::key(&old_prefix),
+                        );
+                    } else {
+                        key = keys::data_key(&k);
+                    }
+                    let value = Cow::Borrowed(&event_iter.val);
+                    // TODO handle delete cf
+                    engine.put_cf(cf, &key, &value)?;
+
+                    smallest_key = smallest_key.map_or(Some(k.clone()), |sk| {
+                        if sk > k { Some(k.clone()) } else { Some(sk) }
+                    });
+                    largest_key = largest_key.map_or(Some(k.clone()), |lk| {
+                        if lk < k { Some(k.clone()) } else { Some(lk) }
+                    });
+                }
+                None => break,
+            }
         }
-        Ok(None)
+        engine.flush_cf(cf, true)?;
+        info!("apply file finished {}", name);
+
+        match (smallest_key, largest_key) {
+            (Some(sk), Some(lk)) => {
+                let mut final_range = Range::default();
+                final_range.set_start(sk);
+                final_range.set_end(lk);
+                Ok(Some(final_range))
+            }
+            _ => Ok(None),
+        }
     }
 
     fn do_download<E: KvEngine>(

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -261,7 +261,7 @@ impl SSTImporter {
             src_file_name,
             dst_file.clone(),
             file_length,
-            &speed_limiter,
+            speed_limiter,
             file_crypter,
         );
         IMPORTER_DOWNLOAD_BYTES.observe(file_length as _);
@@ -306,7 +306,7 @@ impl SSTImporter {
             backend,
             // don't support encrypt for now.
             None,
-            &speed_limiter,
+            speed_limiter,
         )?;
         info!("download file finished {}", name);
 
@@ -329,44 +329,39 @@ impl SSTImporter {
         let mut smallest_key = None;
         let mut largest_key = None;
 
-        loop {
-            match event_iter.next() {
-                Some(k) => {
-                    if perform_rewrite {
-                        let old_key = &k;
+        while let Some(k) = event_iter.next() {
+            if perform_rewrite {
+                let old_key = &k;
 
-                        if !old_key.starts_with(old_prefix) {
-                            return Err(Error::WrongKeyPrefix {
-                                what: "Key in file",
-                                key: old_key.to_vec(),
-                                prefix: old_prefix.to_vec(),
-                            });
-                        }
-                        key.truncate(new_prefix_data_key_len);
-                        key.extend_from_slice(&old_key[old_prefix.len()..]);
-
-                        debug!(
-                            "perform rewrite new key: {:?}, new key prefix: {:?}, old key prefix: {:?}",
-                            log_wrappers::Value::key(keys::origin_key(&key)),
-                            log_wrappers::Value::key(&new_prefix),
-                            log_wrappers::Value::key(&old_prefix),
-                        );
-                    } else {
-                        key = keys::data_key(&k);
-                    }
-                    let value = Cow::Borrowed(&event_iter.val);
-                    // TODO handle delete cf
-                    engine.put_cf(cf, &key, &value)?;
-
-                    smallest_key = smallest_key.map_or(Some(k.clone()), |sk| {
-                        if sk > k { Some(k.clone()) } else { Some(sk) }
-                    });
-                    largest_key = largest_key.map_or(Some(k.clone()), |lk| {
-                        if lk < k { Some(k.clone()) } else { Some(lk) }
+                if !old_key.starts_with(old_prefix) {
+                    return Err(Error::WrongKeyPrefix {
+                        what: "Key in file",
+                        key: old_key.to_vec(),
+                        prefix: old_prefix.to_vec(),
                     });
                 }
-                None => break,
+                key.truncate(new_prefix_data_key_len);
+                key.extend_from_slice(&old_key[old_prefix.len()..]);
+
+                debug!(
+                    "perform rewrite new key: {:?}, new key prefix: {:?}, old key prefix: {:?}",
+                    log_wrappers::Value::key(keys::origin_key(&key)),
+                    log_wrappers::Value::key(new_prefix),
+                    log_wrappers::Value::key(old_prefix),
+                );
+            } else {
+                key = keys::data_key(&k);
             }
+            let value = Cow::Borrowed(&event_iter.val);
+            // TODO handle delete cf
+            engine.put_cf(cf, &key, &value)?;
+
+            smallest_key = smallest_key.map_or(Some(k.clone()), |sk| {
+                if sk > k { Some(k.clone()) } else { Some(sk) }
+            });
+            largest_key = largest_key.map_or(Some(k.clone()), |lk| {
+                if lk < k { Some(k.clone()) } else { Some(lk) }
+            });
         }
         engine.flush_cf(cf, true)?;
         info!("apply file finished {}", name);
@@ -406,7 +401,7 @@ impl SSTImporter {
             path.temp.clone(),
             backend,
             file_crypter,
-            &speed_limiter,
+            speed_limiter,
         )?;
 
         // now validate the SST file.

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -22,7 +22,7 @@ use engine_traits::{
 use file_system::{get_io_rate_limiter, OpenOptions};
 use kvproto::kvrpcpb::ApiVersion;
 use tikv_util::{
-    codec::stream_event::EventIterator,
+    codec::stream_event::{EventIterator, Iterator as EIterator},
     time::{Instant, Limiter},
 };
 use txn_types::{Key, TimeStamp, WriteRef};
@@ -132,7 +132,7 @@ impl SSTImporter {
         self.dir.exist(meta).unwrap_or(false)
     }
 
-    // Donwloads and Apply an KV file from an external storage.
+    // Donwloads and apply a KV file from an external storage.
     pub fn apply<E: KvEngine>(
         &self,
         backend: &StorageBackend,
@@ -299,7 +299,7 @@ impl SSTImporter {
     ) -> Result<Option<Range>> {
         let path = self.dir.get_import_path(name)?;
         self.download_file_from_external_storage(
-            // don't check file lengthn after download file for now.
+            // don't check file length after download file for now.
             0,
             name,
             path.temp.clone(),
@@ -329,9 +329,21 @@ impl SSTImporter {
         let mut smallest_key = None;
         let mut largest_key = None;
 
-        while let Some(k) = event_iter.next() {
+        loop {
+            if event_iter.valid() {
+                break;
+            }
+            event_iter.next()?;
+            let iter_key = event_iter.key().to_vec();
+            smallest_key = smallest_key.map_or(Some(iter_key.clone()), |v: Vec<u8>| {
+                Some(v.min(iter_key.clone()))
+            });
+            largest_key = largest_key.map_or(Some(iter_key.clone()), |v: Vec<u8>| {
+                Some(v.max(iter_key.clone()))
+            });
+
             if perform_rewrite {
-                let old_key = &k;
+                let old_key = event_iter.key();
 
                 if !old_key.starts_with(old_prefix) {
                     return Err(Error::WrongKeyPrefix {
@@ -350,18 +362,11 @@ impl SSTImporter {
                     log_wrappers::Value::key(old_prefix),
                 );
             } else {
-                key = keys::data_key(&k);
+                key = keys::data_key(event_iter.key());
             }
-            let value = Cow::Borrowed(&event_iter.val);
+            let value = Cow::Borrowed(event_iter.value());
             // TODO handle delete cf
             engine.put_cf(cf, &key, &value)?;
-
-            smallest_key = smallest_key.map_or(Some(k.clone()), |sk| {
-                if sk > k { Some(k.clone()) } else { Some(sk) }
-            });
-            largest_key = largest_key.map_or(Some(k.clone()), |lk| {
-                if lk < k { Some(k.clone()) } else { Some(lk) }
-            });
         }
         engine.flush_cf(cf, true)?;
         info!("apply file finished {}", name);

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -298,6 +298,7 @@ impl SSTImporter {
         engine: E,
     ) -> Result<Option<Range>> {
         let path = self.dir.get_import_path(name)?;
+        let start = Instant::now();
         self.download_file_from_external_storage(
             // don't check file length after download file for now.
             0,
@@ -309,6 +310,10 @@ impl SSTImporter {
             speed_limiter,
         )?;
         info!("download file finished {}", name);
+
+        IMPORTER_APPLY_DURATION
+            .with_label_values(&["download"])
+            .observe(start.saturating_elapsed().as_secs_f64());
 
         // iterator `path.temp` file and performs rewrites and apply.
         let file = File::open(path.temp)?;
@@ -329,6 +334,7 @@ impl SSTImporter {
         let mut smallest_key = None;
         let mut largest_key = None;
 
+        let start = Instant::now();
         loop {
             if event_iter.valid() {
                 break;
@@ -369,7 +375,11 @@ impl SSTImporter {
             engine.put_cf(cf, &key, &value)?;
         }
         engine.flush_cf(cf, true)?;
+        let label = if perform_rewrite { "rewrite" } else { "normal" };
         info!("apply file finished {}", name);
+        IMPORTER_APPLY_DURATION
+            .with_label_values(&[label])
+            .observe(start.saturating_elapsed().as_secs_f64());
 
         match (smallest_key, largest_key) {
             (Some(sk), Some(lk)) => {

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::fs::File;
+use std::io::{prelude::*, BufReader};
 
 use futures::executor::ThreadPool;
 use kvproto::brpb::{CipherInfo, StorageBackend};
@@ -19,7 +21,10 @@ use engine_traits::{
 };
 use file_system::{get_io_rate_limiter, OpenOptions};
 use kvproto::kvrpcpb::ApiVersion;
-use tikv_util::time::{Instant, Limiter};
+use tikv_util::{
+    codec::stream_event::EventEncoder,
+    time::{Instant, Limiter},
+};
 use txn_types::{Key, TimeStamp, WriteRef};
 
 use crate::import_file::{ImportDir, ImportFile};
@@ -134,15 +139,20 @@ impl SSTImporter {
         name: &str,
         rewrite_rule: &RewriteRule,
         speed_limiter: Limiter,
-        encoder: Encoder,
         engine: E,
     ) -> Result<Option<Range>> {
-        debug!("download start";
+        debug!("apply start";
             "url" => ?backend,
             "name" => name,
             "rewrite_rule" => ?rewrite_rule,
         );
-        match self.do_download_and_apply::<E>(backend, name, rewrite_rule, &speed_limiter, engine) {
+        match self.do_download_and_apply::<E>(
+            backend,
+            name,
+            rewrite_rule,
+            &speed_limiter,
+            engine,
+        ) {
             Ok(r) => {
                 info!("apply"; "name" => name, "range" => ?r);
                 Ok(r)
@@ -225,7 +235,6 @@ impl SSTImporter {
         src_file_name: &str,
         dst_file: std::path::PathBuf,
         backend: &StorageBackend,
-        rewrite_rule: &RewriteRule,
         file_crypter: Option<FileEncryptionInfo>,
         speed_limiter: &Limiter,
     ) -> Result<()> {
@@ -280,26 +289,32 @@ impl SSTImporter {
         &self,
         backend: &StorageBackend,
         name: &str,
-        rewrite_rule: &RewriteRule,
+        _rewrite_rule: &RewriteRule,
         speed_limiter: &Limiter,
-        engine: E,
+        _engine: E,
     ) -> Result<Option<Range>> {
         let path = self.dir.get_import_path(name)?;
-
         self.download_file_from_external_storage(
             // don't check file lengthn after download file for now.
             0,
             name,
-            path.temp,
+            path.temp.clone(),
             backend,
-            rewrite_rule,
             // don't support encrypt for now.
             None,
             &speed_limiter,
         )?;
 
         // iterator `path.temp` file and performs rewrites and apply.
-        unimplemented!();
+        let file = File::open(path.temp)?;
+        let reader = BufReader::new(file);
+
+        for line in reader.lines() {
+            let (k, v) = EventEncoder::decode_event(line?.as_bytes());
+            println!("key: {:?}, val: {:?}", k, v);
+            // engine.put_cf()
+        }
+        Ok(None)
     }
 
     fn do_download<E: KvEngine>(
@@ -325,7 +340,6 @@ impl SSTImporter {
             name,
             path.temp.clone(),
             backend,
-            rewrite_rule,
             file_crypter,
             &speed_limiter,
         )?;

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -341,10 +341,12 @@ impl SSTImporter {
             }
             event_iter.next()?;
             let iter_key = event_iter.key().to_vec();
-            smallest_key = smallest_key.map_or(Some(iter_key.clone()), |v: Vec<u8>| {
+
+            smallest_key = smallest_key.map_or_else(|| Some(iter_key.clone()), |v: Vec<u8>| {
                 Some(v.min(iter_key.clone()))
             });
-            largest_key = largest_key.map_or(Some(iter_key.clone()), |v: Vec<u8>| {
+
+            largest_key = largest_key.map_or_else(|| Some(iter_key.clone()), |v: Vec<u8>| {
                 Some(v.max(iter_key.clone()))
             });
 

--- a/components/tikv_util/src/codec/mod.rs
+++ b/components/tikv_util/src/codec/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod bytes;
 pub mod number;
+pub mod stream_event;
 
 use std::io::{self, ErrorKind};
 

--- a/components/tikv_util/src/codec/stream_event.rs
+++ b/components/tikv_util/src/codec/stream_event.rs
@@ -4,6 +4,49 @@ use bytes::{Buf, Bytes};
 use std::io::prelude::*;
 use std::io::Cursor;
 
+pub struct EventIterator {
+    buf: Cursor<Vec<u8>>,
+    index: usize,
+    len: usize,
+    pub val: Vec<u8>,
+}
+
+impl EventIterator {
+    pub fn new(buf: Vec<u8>) -> EventIterator {
+        let len = buf.len();
+        EventIterator {
+            buf: Cursor::new(buf),
+            index: 0,
+            len,
+            val: vec![],
+        }
+    }
+}
+
+impl Iterator for EventIterator {
+    type Item = Vec<u8>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            None
+        } else {
+            let len = self.buf.get_u32_le() as usize;
+            self.index += 4;
+            let mut key = vec![0; len];
+            self.buf.read_exact(key.as_mut_slice()).unwrap();
+            self.index += len;
+
+            let len = self.buf.get_u32_le() as usize;
+            self.index += 4;
+            let mut val = vec![0; len];
+            self.buf.read_exact(val.as_mut_slice()).unwrap();
+            self.index += len;
+            self.val = val;
+            Some(key)
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct EventEncoder;
 
@@ -19,7 +62,8 @@ impl EventEncoder {
         ]
     }
 
-    pub fn decode_event(e: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    #[allow(dead_code)]
+    fn decode_event(e: &[u8]) -> (Vec<u8>, Vec<u8>) {
         let mut buf = Cursor::new(Bytes::from(e.to_vec()));
         let len = buf.get_u32_le() as usize;
         let mut key = vec![0; len];

--- a/components/tikv_util/src/codec/stream_event.rs
+++ b/components/tikv_util/src/codec/stream_event.rs
@@ -1,13 +1,13 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+use crate::Either;
 use bytes::{Buf, Bytes};
 use std::io::prelude::*;
 use std::io::Cursor;
-use tikv_util::Either;
 
-pub struct Encoder;
+#[derive(Clone)]
+pub struct EventEncoder;
 
-impl Encoder {
-    // TODO move this function to a indepentent module.
+impl EventEncoder {
     pub fn encode_event<'e>(key: &'e [u8], value: &'e [u8]) -> [impl AsRef<[u8]> + 'e; 4] {
         let key_len = (key.len() as u32).to_le_bytes();
         let val_len = (value.len() as u32).to_le_bytes();
@@ -19,9 +19,8 @@ impl Encoder {
         ]
     }
 
-    #[allow(dead_code)]
     pub fn decode_event(e: &[u8]) -> (Vec<u8>, Vec<u8>) {
-        let mut buf = Cursor::new(Bytes::from(e));
+        let mut buf = Cursor::new(Bytes::from(e.to_vec()));
         let len = buf.get_u32_le() as usize;
         let mut key = vec![0; len];
         buf.read_exact(key.as_mut_slice()).unwrap();
@@ -43,12 +42,12 @@ mod tests {
         for _i in 0..10 {
             let key: Vec<u8> = (0..100).map(|_| rng.gen_range(0..255)).collect();
             let val: Vec<u8> = (0..100).map(|_| rng.gen_range(0..255)).collect();
-            let e = Encoder::encode_event(&key, &val);
+            let e = EventEncoder::encode_event(&key, &val);
             let mut event = vec![];
             for s in e {
                 event.extend_from_slice(s.as_ref());
             }
-            let (decoded_key, decoded_val) = Encoder::decode_event(&event);
+            let (decoded_key, decoded_val) = EventEncoder::decode_event(&event);
             assert_eq!(key, decoded_key);
             assert_eq!(val, decoded_val);
         }

--- a/components/tikv_util/src/codec/stream_event.rs
+++ b/components/tikv_util/src/codec/stream_event.rs
@@ -96,4 +96,34 @@ mod tests {
             assert_eq!(val, decoded_val);
         }
     }
+
+    #[test]
+    fn test_decode_events() {
+        let mut rng = rand::thread_rng();
+        let mut event = vec![];
+        let mut keys = vec![];
+        let mut vals = vec![];
+        let count = 20;
+
+        for _i in 0..count {
+            let key: Vec<u8> = (0..100).map(|_| rng.gen_range(0..255)).collect();
+            let val: Vec<u8> = (0..100).map(|_| rng.gen_range(0..255)).collect();
+            let e = EventEncoder::encode_event(&key, &val);
+            for s in e {
+                event.extend_from_slice(s.as_ref());
+            }
+            keys.push(key);
+            vals.push(val);
+        }
+
+        let mut iter = EventIterator::new(event);
+
+        let mut index = 0_usize;
+        while let Some(k) = iter.next() {
+            assert_eq!(k, keys[index]);
+            assert_eq!(iter.val, vals[index]);
+            index += 1;
+        }
+        assert_eq!(count, index);
+    }
 }

--- a/components/tikv_util/src/codec/stream_event.rs
+++ b/components/tikv_util/src/codec/stream_event.rs
@@ -40,17 +40,15 @@ impl Iterator for EventIterator {
         if self.valid() {
             let len = self.buf.get_u32_le() as usize;
             self.index += 4;
-            let mut key = vec![0; len];
-            self.buf.read_exact(key.as_mut_slice())?;
+            self.key.resize(len, 0);
+            self.buf.read_exact(self.key.as_mut_slice())?;
             self.index += len;
-            self.key = key;
 
             let len = self.buf.get_u32_le() as usize;
             self.index += 4;
-            let mut val = vec![0; len];
-            self.buf.read_exact(val.as_mut_slice())?;
+            self.val.resize(len, 0);
+            self.buf.read_exact(self.val.as_mut_slice())?;
             self.index += len;
-            self.val = val;
         }
         Ok(())
     }

--- a/components/tikv_util/src/codec/stream_event.rs
+++ b/components/tikv_util/src/codec/stream_event.rs
@@ -1,14 +1,25 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
-use crate::Either;
+use crate::{codec::Result, Either};
 use bytes::{Buf, Bytes};
 use std::io::prelude::*;
 use std::io::Cursor;
+
+pub trait Iterator {
+    fn next(&mut self) -> Result<()>;
+
+    fn valid(&self) -> bool;
+
+    fn key(&self) -> &[u8];
+
+    fn value(&self) -> &[u8];
+}
 
 pub struct EventIterator {
     buf: Cursor<Vec<u8>>,
     index: usize,
     len: usize,
-    pub val: Vec<u8>,
+    key: Vec<u8>,
+    val: Vec<u8>,
 }
 
 impl EventIterator {
@@ -18,32 +29,42 @@ impl EventIterator {
             buf: Cursor::new(buf),
             index: 0,
             len,
+            key: vec![],
             val: vec![],
         }
     }
 }
 
 impl Iterator for EventIterator {
-    type Item = Vec<u8>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index >= self.len {
-            None
-        } else {
+    fn next(&mut self) -> Result<()> {
+        if self.valid() {
             let len = self.buf.get_u32_le() as usize;
             self.index += 4;
             let mut key = vec![0; len];
-            self.buf.read_exact(key.as_mut_slice()).unwrap();
+            self.buf.read_exact(key.as_mut_slice())?;
             self.index += len;
+            self.key = key;
 
             let len = self.buf.get_u32_le() as usize;
             self.index += 4;
             let mut val = vec![0; len];
-            self.buf.read_exact(val.as_mut_slice()).unwrap();
+            self.buf.read_exact(val.as_mut_slice())?;
             self.index += len;
             self.val = val;
-            Some(key)
         }
+        Ok(())
+    }
+
+    fn valid(&self) -> bool {
+        self.index < self.len
+    }
+
+    fn key(&self) -> &[u8] {
+        &self.key
+    }
+
+    fn value(&self) -> &[u8] {
+        &self.val
     }
 }
 
@@ -119,9 +140,13 @@ mod tests {
         let mut iter = EventIterator::new(event);
 
         let mut index = 0_usize;
-        while let Some(k) = iter.next() {
-            assert_eq!(k, keys[index]);
-            assert_eq!(iter.val, vals[index]);
+        loop {
+            if !iter.valid() {
+                break;
+            }
+            iter.next().unwrap();
+            assert_eq!(iter.key(), keys[index]);
+            assert_eq!(iter.value(), vals[index]);
             index += 1;
         }
         assert_eq!(count, index);

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -25,7 +25,6 @@ use kvproto::import_sstpb::*;
 use kvproto::raft_cmdpb::*;
 
 use crate::server::CONFIG_ROCKSDB_GAUGE;
-use br_stream::codec::Encoder;
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::{Callback, RaftCmdExtraOpts, RegionSnapshot};
 use tikv_util::future::create_stream_with_buffer;
@@ -47,7 +46,6 @@ where
 {
     cfg: Config,
     engine: E,
-    encoder: Encoder,
     router: Router,
     threads: ThreadPool,
     importer: Arc<SSTImporter>,
@@ -87,7 +85,6 @@ where
         ImportSSTService {
             cfg,
             engine,
-            encoder: Encoder,
             threads,
             router,
             importer,
@@ -377,7 +374,6 @@ where
         let timer = Instant::now_coarse();
         let importer = Arc::clone(&self.importer);
         let engine = self.engine.clone();
-        let encoder = self.encoder.clone();
         let limiter = self.limiter.clone();
         let start = Instant::now();
 
@@ -398,7 +394,7 @@ where
             match res {
                 Ok(range) => match range {
                     Some(r) => resp.set_range(r),
-                    None => resp.set_error("no file applyed"),
+                    None => unimplemented!(),
                 },
                 Err(e) => resp.set_error(e.into()),
             }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -25,6 +25,7 @@ use kvproto::import_sstpb::*;
 use kvproto::raft_cmdpb::*;
 
 use crate::server::CONFIG_ROCKSDB_GAUGE;
+use br_stream::codec::Encoder;
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::{Callback, RaftCmdExtraOpts, RegionSnapshot};
 use tikv_util::future::create_stream_with_buffer;
@@ -46,6 +47,7 @@ where
 {
     cfg: Config,
     engine: E,
+    encoder: Encoder,
     router: Router,
     threads: ThreadPool,
     importer: Arc<SSTImporter>,
@@ -85,6 +87,7 @@ where
         ImportSSTService {
             cfg,
             engine,
+            encoder: Encoder,
             threads,
             router,
             importer,
@@ -365,6 +368,44 @@ where
         };
 
         self.threads.spawn_ok(buf_driver);
+        self.threads.spawn_ok(handle_task);
+    }
+
+    // Downloads KV file and performs key-rewrite then apply kv into this tikv store.
+    fn apply(&mut self, _ctx: RpcContext<'_>, req: ApplyRequest, sink: UnarySink<ApplyResponse>) {
+        let label = "apply";
+        let timer = Instant::now_coarse();
+        let importer = Arc::clone(&self.importer);
+        let engine = self.engine.clone();
+        let encoder = self.encoder.clone();
+        let limiter = self.limiter.clone();
+        let start = Instant::now();
+
+        let handle_task = async move {
+            // Records how long the apply task waits to be scheduled.
+            sst_importer::metrics::IMPORTER_APPLY_DURATION
+                .with_label_values(&["queue"])
+                .observe(start.saturating_elapsed().as_secs_f64());
+
+            let res = importer.apply::<E>(
+                req.get_storage_backend(),
+                req.get_name(),
+                req.get_rewrite_rule(),
+                limiter,
+                engine,
+            );
+            let mut resp = ApplyResponse::default();
+            match res {
+                Ok(range) => match range {
+                    Some(r) => resp.set_range(r),
+                    None => resp.set_error("no file applyed"),
+                },
+                Err(e) => resp.set_error(e.into()),
+            }
+            let resp = Ok(resp);
+            crate::send_rpc_response!(resp, sink, label, timer);
+        };
+
         self.threads.spawn_ok(handle_task);
     }
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -387,6 +387,7 @@ where
                 req.get_storage_backend(),
                 req.get_name(),
                 req.get_rewrite_rule(),
+                req.get_cf(),
                 limiter,
                 engine,
             );
@@ -394,7 +395,7 @@ where
             match res {
                 Ok(range) => match range {
                     Some(r) => resp.set_range(r),
-                    None => unimplemented!(),
+                    None => (),
                 },
                 Err(e) => resp.set_error(e.into()),
             }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -393,10 +393,11 @@ where
             );
             let mut resp = ApplyResponse::default();
             match res {
-                Ok(range) => match range {
-                    Some(r) => resp.set_range(r),
-                    None => (),
-                },
+                Ok(range) => {
+                    if let Some(r) = range {
+                        resp.set_range(r);
+                    }
+                }
                 Err(e) => resp.set_error(e.into()),
             }
             let resp = Ok(resp);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close https://github.com/pingcap/tidb/issues/31979 and https://github.com/pingcap/tidb/issues/31980

What's Changed:
1. implement apply interface for sst_importer.
2. move `components/br-stream/src/codec.rs` to tikv_util for sst_importer.
### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
