### PR TITLE
add flush tick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,8 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes 0.4.12",
+ "crossbeam",
+ "crossbeam-channel",
  "dashmap 5.0.0",
  "engine_panic",
  "engine_rocks",

--- a/components/br-stream/Cargo.toml
+++ b/components/br-stream/Cargo.toml
@@ -38,6 +38,8 @@ hex = "0.4"
 uuid = "0.8"
 openssl = "0.10"
 dashmap = "5"
+crossbeam = "0.8"
+crossbeam-channel = "0.5"
 
 file_system = { path = "../file_system" }
 tidb_query_datatype = {path = "../tidb_query_datatype", default-features = false}

--- a/components/br-stream/src/endpoint.rs
+++ b/components/br-stream/src/endpoint.rs
@@ -4,14 +4,16 @@ use std::convert::AsRef;
 use std::fmt;
 use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use engine_traits::KvEngine;
 
 use kvproto::metapb::Region;
 use raftstore::router::RaftStoreRouter;
-
 use raftstore::store::fsm::ChangeObserver;
 use tikv_util::time::Instant;
+
+use crossbeam_channel::tick;
 use tokio::io::Result as TokioResult;
 use tokio::runtime::Runtime;
 use tokio_stream::StreamExt;
@@ -102,6 +104,11 @@ where
                     err.report("failed to start watch tasks");
                 }
             });
+            pool.spawn(Endpoint::<_, R, E, RT>::starts_flush_ticks(
+                meta_client.clone(),
+                scheduler.clone(),
+                range_router.clone(),
+            ));
         }
 
         Endpoint {
@@ -126,6 +133,40 @@ where
     E: KvEngine,
     RT: RaftStoreRouter<E> + 'static,
 {
+    async fn starts_flush_ticks(
+        meta_client: MetadataClient<S>,
+        scheduler: Scheduler<Task>,
+        router: Router,
+    ) -> Result<()> {
+        let ticker = tick(Duration::from_secs(10));
+        loop {
+            // wait 10s to trigger tick
+            let _ = ticker.recv().unwrap();
+            debug!("backup stream trigger flush tick");
+            match meta_client.get_tasks().await {
+                Ok(tasks) => {
+                    for task in tasks.inner {
+                        debug!("backup stream get task in flush tick"; "task" => ?task);
+                        match router.get_task_info(&task.info.name).await {
+                            Ok(task_info) => {
+                                if task_info.should_flush() {
+                                    info!("backup stream trigger flush task by tick"; "task" => ?task);
+                                    if let Err(e) =
+                                        scheduler.schedule(Task::Flush(task.info.name.to_string()))
+                                    {
+                                        error!("backup stream schedule task failed"; "error" => ?e);
+                                    }
+                                }
+                            }
+                            Err(e) => error!("backup stream get task failed"; "error" => ?e),
+                        }
+                    }
+                }
+                Err(e) => error!("backup stream get tasks failed"; "error" => ?e),
+            };
+        }
+    }
+
     // TODO find a proper way to exit watch tasks
     async fn starts_watch_tasks(
         meta_client: MetadataClient<S>,

--- a/components/br-stream/src/metrics.rs
+++ b/components/br-stream/src/metrics.rs
@@ -40,10 +40,11 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
-    pub static ref ON_EVENT_COST_HISTOGRAM : HistogramVec = register_histogram_vec!(
+    pub static ref ON_EVENT_COST_HISTOGRAM: HistogramVec = register_histogram_vec!(
         "tikv_stream_on_event_duration_seconds",
         "The time cost of handling events.",
         &["stage"],
         exponential_buckets(0.001, 2.0, 16).unwrap()
-    ).unwrap();
+    )
+    .unwrap();
 }

--- a/components/br-stream/src/observer.rs
+++ b/components/br-stream/src/observer.rs
@@ -1,6 +1,6 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 use std::sync::{Arc, RwLock};
 
-// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 use crate::errors::Error;
 use crate::utils::SegmentTree;
 use dashmap::DashMap;

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -586,8 +586,11 @@ impl StreamTaskInfo {
     }
 
     pub fn update_flush_time(&self) {
-        self.last_flush_time
-            .store(Box::into_raw(Box::new(Instant::now())), Ordering::SeqCst);
+        let ptr = self
+            .last_flush_time
+            .swap(Box::into_raw(Box::new(Instant::now())), Ordering::SeqCst);
+        // manual gc last instant
+        unsafe { Box::from_raw(ptr) };
     }
 
     pub fn should_flush(&self) -> bool {

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -5,9 +5,10 @@ use std::{
     path::{Path, PathBuf},
     result,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering},
         Arc, RwLock as SyncRwLock,
     },
+    time::Duration,
 };
 
 use crate::{
@@ -38,7 +39,7 @@ use slog_global::debug;
 use tidb_query_datatype::codec::table::decode_table_id;
 
 use tikv_util::{
-    box_err, defer, info,
+    box_err, defer, error, info,
     time::{Instant, Limiter},
     warn,
     worker::Scheduler,
@@ -48,6 +49,8 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 use tokio::{fs::remove_file, fs::File};
 use txn_types::{Key, TimeStamp};
+
+const FLUSH_STORAGE_INTERVAL: u64 = 300;
 
 #[derive(Debug)]
 pub struct ApplyEvent {
@@ -298,6 +301,19 @@ impl RouterInner {
             )
     }
 
+    pub async fn get_task_info(&self, task_name: &str) -> Result<Arc<StreamTaskInfo>> {
+        let task_info = match self.tasks.lock().await.get(task_name) {
+            Some(t) => t.clone(),
+            None => {
+                info!("backup stream no task"; "task" => ?task_name);
+                return Err(Error::NoSuchTask {
+                    task_name: task_name.to_string(),
+                });
+            }
+        };
+        Ok(task_info)
+    }
+
     pub async fn on_event(&self, kv: ApplyEvent) -> Result<()> {
         if let Some(task) = self.get_task_by_key(&kv.key) {
             debug!(
@@ -307,13 +323,7 @@ impl RouterInner {
                 "key" => &log_wrappers::Value::key(&kv.key),
             );
 
-            let task_info = match self.tasks.lock().await.get(&task) {
-                Some(t) => t.clone(),
-                None => {
-                    info!("backup stream no task"; "task" => ?task);
-                    return Err(Error::NoSuchTask { task_name: task });
-                }
-            };
+            let task_info = self.get_task_info(&task).await?;
             task_info.on_event(kv).await?;
 
             // When this event make the size of temporary files exceeds the size limit, make a flush.
@@ -326,14 +336,10 @@ impl RouterInner {
                 "size_limit" => self.temp_file_size_limit,
             );
             let cur_size = task_info.total_size();
-            if cur_size > self.temp_file_size_limit && !task_info.is_flushing() {
+            if cur_size > self.temp_file_size_limit {
                 info!("try flushing task"; "task" => %task, "size" => %cur_size);
-                if task_info.set_flushing_status_cas(false, true).is_ok() {
-                    // delay the schedule when failure? (Why the scheduler doesn't support blocking send...)
-                    if self.scheduler.schedule(Task::Flush(task)).is_err() {
-                        // oops... we failed, let's leave the chance to next challenger.
-                        task_info.set_flushing_status(false);
-                    }
+                if let Err(e) = self.scheduler.schedule(Task::Flush(task)) {
+                    error!("backup stream schedule task failed"; "error" => ?e);
                 }
             }
         }
@@ -343,11 +349,14 @@ impl RouterInner {
     pub async fn do_flush(&self, task_name: &str, store_id: u64) {
         debug!("backup stream do flush"; "task" => task_name);
         if let Some(task_info) = self.tasks.lock().await.get(task_name) {
-            if let Err(e) = task_info.do_flush(store_id).await {
-                warn!("backup steam do flush fail"; "err" => ?e);
+            if task_info.set_flushing_status_cas(false, true).is_ok() {
+                if let Err(e) = task_info.do_flush(store_id).await {
+                    warn!("backup steam do flush fail"; "err" => ?e);
+                }
             }
             // set false to flushing whether success or fail
             task_info.set_flushing_status(false);
+            task_info.update_flush_time();
         }
     }
 }
@@ -454,6 +463,10 @@ pub struct StreamTaskInfo {
     files: SlotMap<TempFileKey, DataFile>,
     /// flushing_files contains files pending flush.
     flushing_files: SlotMap<TempFileKey, DataFile>,
+    /// last_flush_ts represents last time this task flushed to storage.
+    last_flush_time: AtomicPtr<Instant>,
+    /// flush_interval represents the tick interval of flush, setting by users.
+    flush_interval: Duration,
     /// The min resolved TS of all regions involved.
     min_resolved_ts: TimeStamp,
     /// Total size of all temporary files in byte.
@@ -492,6 +505,9 @@ impl StreamTaskInfo {
             min_resolved_ts: TimeStamp::max(),
             files: SlotMap::default(),
             flushing_files: SlotMap::default(),
+            last_flush_time: AtomicPtr::new(Box::into_raw(Box::new(Instant::now()))),
+            // TODO make this config set by config or task?
+            flush_interval: Duration::from_secs(FLUSH_STORAGE_INTERVAL),
             total_size: AtomicUsize::new(0),
             flushing: AtomicBool::new(false),
         })
@@ -528,6 +544,10 @@ impl StreamTaskInfo {
         Ok(())
     }
 
+    pub fn get_last_flush_time(&self) -> Instant {
+        unsafe { *(self.last_flush_time.load(Ordering::SeqCst) as *const Instant) }
+    }
+
     pub fn total_size(&self) -> u64 {
         self.total_size.load(Ordering::SeqCst) as _
     }
@@ -562,6 +582,15 @@ impl StreamTaskInfo {
 
     pub fn set_flushing_status(&self, set_flushing: bool) {
         self.flushing.store(set_flushing, Ordering::SeqCst);
+    }
+
+    pub fn update_flush_time(&self) {
+        self.last_flush_time
+            .store(Box::into_raw(Box::new(Instant::now())), Ordering::SeqCst);
+    }
+
+    pub fn should_flush(&self) -> bool {
+        self.get_last_flush_time().saturating_elapsed() >= self.flush_interval
     }
 
     pub fn is_flushing(&self) -> bool {


### PR DESCRIPTION
Signed-off-by: 3pointer <luancheng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:
1. add a 5min interval to flush temporary files to s3.
2. fix the issue that remove the flush lock on schedule.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
