### PR TITLE
Added resolved timestamp uploading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "raftstore",
  "rand 0.8.3",
  "regex",
+ "resolved_ts",
  "slog",
  "slog-global",
  "thiserror",

--- a/components/br-stream/Cargo.toml
+++ b/components/br-stream/Cargo.toml
@@ -47,6 +47,7 @@ raft = { version = "0.6.0-alpha", default-features = false, features = ["protobu
 raftstore = { path = "../raftstore", default-features = false }
 tikv = { path = "../../", default-features = false }
 online_config = { path = "../online_config" }
+resolved_ts = { path = "../resolved_ts"}
 
 [dev-dependencies]
 rand = "0.8.0"

--- a/components/br-stream/src/endpoint.rs
+++ b/components/br-stream/src/endpoint.rs
@@ -389,7 +389,7 @@ where
         let handle = ObserveHandle::new();
         let region_id = region.get_id();
         let ob = ChangeObserver::from_cdc(region_id, handle.clone());
-        init.observe_over(&region, ob)?;
+        init.observe_over(region, ob)?;
         self.observer.subs.register_region(region_id, handle);
         self.resolvers.insert(region.id, Resolver::new(region.id));
         Ok(())

--- a/components/br-stream/src/metrics.rs
+++ b/components/br-stream/src/metrics.rs
@@ -40,10 +40,11 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
-    pub static ref ON_EVENT_COST_HISTOGRAM : HistogramVec = register_histogram_vec!(
+    pub static ref ON_EVENT_COST_HISTOGRAM: HistogramVec = register_histogram_vec!(
         "tikv_stream_on_event_duration_seconds",
         "The time cost of handling events.",
         &["stage"],
         exponential_buckets(0.001, 2.0, 16).unwrap()
-    ).unwrap();
+    )
+    .unwrap();
 }

--- a/components/br-stream/src/metrics.rs
+++ b/components/br-stream/src/metrics.rs
@@ -47,4 +47,10 @@ lazy_static! {
         exponential_buckets(0.001, 2.0, 16).unwrap()
     )
     .unwrap();
+    pub static ref STORE_CHECKPOINT_TS: IntGaugeVec = register_int_gauge_vec!(
+        "tikv_stream_store_checkpoint_ts",
+        "The checkpoint ts (next backup ts) of task",
+        &["task"],
+    )
+    .unwrap();
 }

--- a/components/br-stream/src/observer.rs
+++ b/components/br-stream/src/observer.rs
@@ -1,6 +1,6 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 use std::sync::{Arc, RwLock};
 
-// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 use crate::errors::Error;
 use crate::utils::SegmentTree;
 use dashmap::DashMap;

--- a/components/br-stream/src/observer.rs
+++ b/components/br-stream/src/observer.rs
@@ -184,10 +184,6 @@ impl RegionChangeObserver for BackupStreamObserver {
         event: RegionChangeEvent,
         _role: StateRole,
     ) {
-        // No need for handling `Create` -- once it becomes leader, it would start by
-        // `on_applied_current_term`.
-        // But should we deregister and register again when the region is `Update`d?
-
         match event {
             RegionChangeEvent::Destroy if self.subs.should_observe(ctx.region().get_id()) => {
                 try_send!(
@@ -205,6 +201,8 @@ impl RegionChangeObserver for BackupStreamObserver {
                     })
                 );
             }
+            // No need for handling `Create` -- once it becomes leader, it would start by
+            // `on_applied_current_term`.
             _ => {}
         }
     }

--- a/components/br-stream/src/observer.rs
+++ b/components/br-stream/src/observer.rs
@@ -2,6 +2,7 @@
 use std::sync::{Arc, RwLock};
 
 use crate::errors::Error;
+use crate::try_send;
 use crate::utils::SegmentTree;
 use dashmap::DashMap;
 use engine_traits::KvEngine;
@@ -12,7 +13,7 @@ use tikv_util::worker::Scheduler;
 use tikv_util::{debug, warn};
 use tikv_util::{info, HandyRwLock};
 
-use crate::endpoint::Task;
+use crate::endpoint::{ObserveOp, Task};
 
 /// An Observer for Backup Stream.
 ///
@@ -52,9 +53,12 @@ impl BackupStreamObserver {
     /// The internal way to register a region.
     /// It delegate the initial scanning and modify of the subs to the endpoint.
     fn register_region(&self, region: &Region) {
-        if let Err(err) = self.scheduler.schedule(Task::ObserverRegion {
-            region: region.clone(),
-        }) {
+        if let Err(err) = self
+            .scheduler
+            .schedule(Task::ModifyObserve(ObserveOp::Start {
+                region: region.clone(),
+            }))
+        {
             Error::from(err).report(format_args!(
                 "failed to schedule role change for region {}",
                 region.get_id()
@@ -150,9 +154,7 @@ impl<E: KvEngine> CmdObserver<E> for BackupStreamObserver {
         if cmd_batches.is_empty() {
             return;
         }
-        if let Err(e) = self.scheduler.schedule(Task::BatchEvent(cmd_batches)) {
-            warn!("backup stream schedule task failed"; "error" => ?e);
-        }
+        try_send!(self.scheduler, Task::BatchEvent(cmd_batches));
     }
 
     fn on_applied_current_term(&self, role: StateRole, region: &Region) {
@@ -165,8 +167,12 @@ impl<E: KvEngine> CmdObserver<E> for BackupStreamObserver {
 impl RoleObserver for BackupStreamObserver {
     fn on_role_change(&self, ctx: &mut ObserverContext<'_>, r: StateRole) {
         if r != StateRole::Leader {
-            let region = ctx.region();
-            self.subs.deregister_region(region.get_id());
+            try_send!(
+                self.scheduler,
+                Task::ModifyObserve(ObserveOp::Stop {
+                    region: ctx.region().clone(),
+                })
+            );
         }
     }
 }
@@ -182,10 +188,24 @@ impl RegionChangeObserver for BackupStreamObserver {
         // `on_applied_current_term`.
         // But should we deregister and register again when the region is `Update`d?
 
-        if matches!(event, RegionChangeEvent::Destroy)
-            && self.subs.should_observe(ctx.region().get_id())
-        {
-            self.subs.deregister_region(ctx.region().get_id())
+        match event {
+            RegionChangeEvent::Destroy if self.subs.should_observe(ctx.region().get_id()) => {
+                try_send!(
+                    self.scheduler,
+                    Task::ModifyObserve(ObserveOp::Stop {
+                        region: ctx.region().clone(),
+                    })
+                );
+            }
+            RegionChangeEvent::Update => {
+                try_send!(
+                    self.scheduler,
+                    Task::ModifyObserve(ObserveOp::RefreshResolver {
+                        region: ctx.region().clone(),
+                    })
+                );
+            }
+            _ => {}
         }
     }
 }
@@ -207,7 +227,7 @@ mod tests {
     use tikv_util::worker::dummy_scheduler;
     use tikv_util::HandyRwLock;
 
-    use crate::endpoint::Task;
+    use crate::endpoint::{ObserveOp, Task};
 
     use super::BackupStreamObserver;
 
@@ -232,7 +252,7 @@ mod tests {
         o.register_region(&r);
         let task = rx.recv_timeout(Duration::from_secs(0)).unwrap().unwrap();
         let handle = ObserveHandle::new();
-        if let Task::ObserverRegion { region } = task {
+        if let Task::ModifyObserve(ObserveOp::Start { region }) = task {
             o.subs.register_region(region.get_id(), handle.clone())
         } else {
             panic!("unexpected message received: it is {}", task);
@@ -256,7 +276,7 @@ mod tests {
         o.register_region(&r);
         let task = rx.recv_timeout(Duration::from_secs(0)).unwrap().unwrap();
         let handle = ObserveHandle::new();
-        if let Task::ObserverRegion { region } = task {
+        if let Task::ModifyObserve(ObserveOp::Start { region }) = task {
             o.subs.register_region(region.get_id(), handle.clone())
         } else {
             panic!("unexpected message received: it is {}", task);

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -113,8 +113,9 @@ impl ApplyEvent {
                         }
                     }
                     CmdType::Delete => resolver.untrack_lock(&key, None),
-                    _ => continue,
+                    _ => {}
                 }
+                continue;
             }
             // use the key ts as min_ts would be safe.
             // - if it is uncommitted, the lock would be tracked, preventing resolved ts

--- a/components/br-stream/src/utils.rs
+++ b/components/br-stream/src/utils.rs
@@ -6,7 +6,10 @@ use std::{
     time::Duration,
 };
 
-use crate::errors::{Error, Result};
+use crate::{
+    annotate,
+    errors::{Error, Result},
+};
 
 use engine_traits::CF_DEFAULT;
 use futures::{channel::mpsc, executor::block_on, StreamExt};
@@ -28,11 +31,11 @@ pub fn wrap_key(v: Vec<u8>) -> Vec<u8> {
 /// decode ts from a key, and transform the error to the crate error.
 pub fn get_ts(key: &Key) -> Result<TimeStamp> {
     key.decode_ts().map_err(|err| {
-        Error::Other(box_err!(
-            "failed to get ts from key '{}': {}",
-            log_wrappers::Value::key(key.as_encoded().as_slice()),
-            err
-        ))
+        annotate!(
+            err,
+            "failed to get ts from key '{}'",
+            redact(&key.as_encoded())
+        )
     })
 }
 

--- a/components/br-stream/src/utils.rs
+++ b/components/br-stream/src/utils.rs
@@ -207,6 +207,29 @@ pub fn request_to_triple(mut req: Request) -> Either<(Vec<u8>, Vec<u8>, String),
     Either::Left((key, value, cf))
 }
 
+/// `try_send!(s: Scheduler<T>, task: T)` tries to send a task to the scheduler,
+/// once meet an error, would report it, with the current file and line (so it is made as a macro).    
+/// returns whether it success.
+#[macro_export(crate)]
+macro_rules! try_send {
+    ($s: expr, $task: expr) => {
+        match $s.schedule($task) {
+            Err(err) => {
+                $crate::errors::Error::from(err).report(concat!(
+                    "[",
+                    file!(),
+                    ":",
+                    line!(),
+                    "]",
+                    "failed to schedule task"
+                ));
+                false
+            }
+            Ok(_) => true,
+        }
+    };
+}
+
 #[cfg(test)]
 mod test {
     use super::SegmentTree;


### PR DESCRIPTION
1. Calculate the resolved TS when receiving events.
2. Upload the resolved TS as `next_backup_ts` (a.k.a. `checkpoint_ts`) after flushing.

Note: Most of the logic are copied from `resolved_ts::Endpoint` and `resolved_ts::Observer`, should we just adapt it when it get ready?