### PR TITLE
br: don't flush to externStorage periodically when have empty kv-record

### DIFF
--- a/components/br-stream/src/endpoint.rs
+++ b/components/br-stream/src/endpoint.rs
@@ -108,9 +108,7 @@ where
                     err.report("failed to start watch tasks");
                 }
             });
-            pool.spawn(Endpoint::<_, R, E, RT>::starts_flush_ticks(
-                meta_client.clone(),
-                scheduler.clone(),
+            pool.spawn(Endpoint::<EtcdStore, R, E, RT>::starts_flush_ticks(
                 range_router.clone(),
             ));
         }
@@ -139,35 +137,13 @@ where
     E: KvEngine,
     RT: RaftStoreRouter<E> + 'static,
 {
-    async fn starts_flush_ticks(
-        meta_client: MetadataClient<S>,
-        scheduler: Scheduler<Task>,
-        router: Router,
-    ) -> Result<()> {
+    async fn starts_flush_ticks(router: Router) {
         let ticker = tick(Duration::from_secs(10));
         loop {
             // wait 10s to trigger tick
             let _ = ticker.recv().unwrap();
             debug!("backup stream trigger flush tick");
-            match meta_client.get_tasks().await {
-                Ok(tasks) => {
-                    for task in tasks.inner {
-                        debug!("backup stream get task in flush tick"; "task" => ?task);
-                        router.get_task_info(&task.info.name).await.and_then(|task_info| {
-                            if task_info.should_flush() && !task_info.is_flushing() && task_info.set_flushing_status_cas(false, true).is_ok() {
-                                info!("backup stream trigger flush task by tick"; "task" => ?task);
-                                scheduler.schedule(Task::Flush(task.info.name.to_string())).map_err(|e| {
-                                    error!("backup stream schedule task failed"; "error" => ?e);
-                                    e.into()
-                                })
-                            } else {
-                                Ok(())
-                            }
-                        })?;
-                    }
-                }
-                Err(e) => error!("backup stream get tasks failed"; "error" => ?e),
-            }
+            router.tick().await;
         }
     }
 

--- a/components/br-stream/src/endpoint.rs
+++ b/components/br-stream/src/endpoint.rs
@@ -26,7 +26,7 @@ use crate::event_loader::InitialDataLoader;
 use crate::metadata::store::{EtcdStore, MetaStore};
 use crate::metadata::{MetadataClient, MetadataEvent, StreamTask};
 use crate::metrics;
-use crate::router::{ApplyEvent, Router};
+use crate::router::{ApplyEvent, Router, FLUSH_STORAGE_INTERVAL};
 use crate::utils::{self, StopWatch};
 use crate::{errors::Result, observer::BackupStreamObserver};
 
@@ -138,7 +138,7 @@ where
     RT: RaftStoreRouter<E> + 'static,
 {
     async fn starts_flush_ticks(router: Router) {
-        let ticker = tick(Duration::from_secs(10));
+        let ticker = tick(Duration::from_secs(FLUSH_STORAGE_INTERVAL / 5));
         loop {
             // wait 10s to trigger tick
             let _ = ticker.recv().unwrap();

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -418,7 +418,7 @@ impl RouterInner {
                     error!("backup stream schedule task failed"; "error" => ?e);
                     task_info.set_flushing_status(false);
                 }
-            }else{
+            } else {
                 task_info.update_flush_time();
             }
         }

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -402,8 +402,10 @@ impl RouterInner {
         }
     }
 
+    /// tick aims to flush log/meta to extern storage periodically.
     pub async fn tick(&self) {
         for (name, task_info) in self.tasks.lock().await.iter() {
+            // if stream task need flush this time, schedule Task::Flush, or update time justly.
             if task_info.should_flush().await
                 && task_info.set_flushing_status_cas(false, true).is_ok()
             {
@@ -416,6 +418,8 @@ impl RouterInner {
                     error!("backup stream schedule task failed"; "error" => ?e);
                     task_info.set_flushing_status(false);
                 }
+            }else{
+                task_info.update_flush_time();
             }
         }
     }

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -53,7 +53,7 @@ use tokio::sync::Mutex;
 use tokio::{fs::remove_file, fs::File};
 use txn_types::{Key, Lock, TimeStamp};
 
-const FLUSH_STORAGE_INTERVAL: u64 = 300;
+pub const FLUSH_STORAGE_INTERVAL: u64 = 300;
 
 #[derive(Debug)]
 pub struct ApplyEvent {
@@ -418,8 +418,6 @@ impl RouterInner {
                     error!("backup stream schedule task failed"; "error" => ?e);
                     task_info.set_flushing_status(false);
                 }
-            } else {
-                task_info.update_flush_time();
             }
         }
     }

--- a/components/resource_metering/src/utils.rs
+++ b/components/resource_metering/src/utils.rs
@@ -28,7 +28,8 @@ pub fn thread_id() -> usize {
 /// Gets the ID of the current thread.
 #[cfg(not(target_os = "linux"))]
 pub fn thread_id() -> usize {
-    thread_id::get()
+    // thread_id::get()
+    1
 }
 
 /// Get all thread id collections under the current process.

--- a/components/resource_metering/src/utils.rs
+++ b/components/resource_metering/src/utils.rs
@@ -28,8 +28,7 @@ pub fn thread_id() -> usize {
 /// Gets the ID of the current thread.
 #[cfg(not(target_os = "linux"))]
 pub fn thread_id() -> usize {
-    // thread_id::get()
-    1
+    thread_id::get()
 }
 
 /// Get all thread id collections under the current process.

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -342,13 +342,15 @@ impl SSTImporter {
             event_iter.next()?;
             let iter_key = event_iter.key().to_vec();
 
-            smallest_key = smallest_key.map_or_else(|| Some(iter_key.clone()), |v: Vec<u8>| {
-                Some(v.min(iter_key.clone()))
-            });
+            smallest_key = smallest_key.map_or_else(
+                || Some(iter_key.clone()),
+                |v: Vec<u8>| Some(v.min(iter_key.clone())),
+            );
 
-            largest_key = largest_key.map_or_else(|| Some(iter_key.clone()), |v: Vec<u8>| {
-                Some(v.max(iter_key.clone()))
-            });
+            largest_key = largest_key.map_or_else(
+                || Some(iter_key.clone()),
+                |v: Vec<u8>| Some(v.max(iter_key.clone())),
+            );
 
             if perform_rewrite {
                 let old_key = event_iter.key();


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Close https://github.com/pingcap/tidb/issues/29971

What's Changed:

- If not observe kv event, don't to flush to externStorage periodically.
- It has test manually.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
