### PR TITLE
br-stream: add restore ts to filter data out of range.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,7 +2283,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=br-stream#11c47a2c2f8e3c59b4cb12abd479675eaad69f3b"
+source = "git+https://github.com/pingcap/kvproto.git?branch=br-stream#f7a5a196e62914231a97877a7f4c95a00049eff3"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -782,7 +782,7 @@ impl MetadataInfo {
         let mut metadata = Metadata::new();
         metadata.set_files(self.files.into());
         metadata.set_store_id(self.store_id as _);
-        metadata.set_resloved_ts(self.min_resolved_ts as _);
+        metadata.set_resolved_ts(self.min_resolved_ts as _);
 
         metadata
             .write_to_bytes()

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -340,7 +340,7 @@ impl SSTImporter {
             event_iter.next()?;
             let iter_key = event_iter.key().to_vec();
 
-            let ts = Key::from_encoded(iter_key.clone()).decode_ts()?;
+            let ts = Key::decode_ts_from(&iter_key)?;
             if ts > TimeStamp::new(meta.get_restore_ts()) {
                 // we assume the keys in file are sorted by ts. 
                 // so if we met the key not satisfy the ts. 
@@ -352,7 +352,6 @@ impl SSTImporter {
                 || Some(iter_key.clone()),
                 |v: Vec<u8>| Some(v.min(iter_key.clone())),
             );
-
 
             largest_key = largest_key.map_or_else(
                 || Some(iter_key.clone()),

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -135,33 +135,30 @@ impl SSTImporter {
     // Donwloads and apply a KV file from an external storage.
     pub fn apply<E: KvEngine>(
         &self,
+        meta: &KvMeta,
         backend: &StorageBackend,
-        name: &str,
         rewrite_rule: &RewriteRule,
-        cf: &str,
         speed_limiter: Limiter,
         engine: E,
     ) -> Result<Option<Range>> {
         debug!("apply start";
             "url" => ?backend,
-            "name" => name,
-            "cf" => cf,
+            "meta" => ?meta,
             "rewrite_rule" => ?rewrite_rule,
         );
         match self.do_download_and_apply::<E>(
+            meta,
             backend,
-            name,
             rewrite_rule,
-            cf,
             &speed_limiter,
             engine,
         ) {
             Ok(r) => {
-                info!("apply"; "name" => name, "range" => ?r);
+                info!("apply"; "meta" => ?meta, "range" => ?r);
                 Ok(r)
             }
             Err(e) => {
-                error!(%e; "apply failed"; "name" => name,);
+                error!(%e; "apply failed"; "meta" => ?meta,);
                 Err(e)
             }
         }
@@ -290,18 +287,19 @@ impl SSTImporter {
 
     fn do_download_and_apply<E: KvEngine>(
         &self,
+        meta: &KvMeta,
         backend: &StorageBackend,
-        name: &str,
         rewrite_rule: &RewriteRule,
-        cf: &str,
         speed_limiter: &Limiter,
         engine: E,
     ) -> Result<Option<Range>> {
+        let name = meta.get_name();
+        let cf = meta.get_cf();
         let path = self.dir.get_import_path(name)?;
         let start = Instant::now();
         self.download_file_from_external_storage(
-            // don't check file length after download file for now.
-            0,
+            // current length is 0. which means won't check the file length.
+            meta.get_length(),
             name,
             path.temp.clone(),
             backend,
@@ -342,10 +340,19 @@ impl SSTImporter {
             event_iter.next()?;
             let iter_key = event_iter.key().to_vec();
 
+            let ts = Key::from_encoded(iter_key.clone()).decode_ts()?;
+            if ts > TimeStamp::new(meta.get_restore_ts()) {
+                // we assume the keys in file are sorted by ts. 
+                // so if we met the key not satisfy the ts. 
+                // we can easily filter the remain keys.
+                break
+            }
+
             smallest_key = smallest_key.map_or_else(
                 || Some(iter_key.clone()),
                 |v: Vec<u8>| Some(v.min(iter_key.clone())),
             );
+
 
             largest_key = largest_key.map_or_else(
                 || Some(iter_key.clone()),

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -384,10 +384,9 @@ where
                 .observe(start.saturating_elapsed().as_secs_f64());
 
             let res = importer.apply::<E>(
+                req.get_meta(),
                 req.get_storage_backend(),
-                req.get_name(),
                 req.get_rewrite_rule(),
-                req.get_cf(),
                 limiter,
                 engine,
             );


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: along with https://github.com/pingcap/tidb/pull/32250.
What's Changed:
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
1. add restore ts to filter data out of range.
2. fix the typo `resloved_ts` to `resolved_ts`.
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below) 
    see #https://github.com/pingcap/tidb/pull/32250
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
