### PR TITLE
added user safe point

### DIFF
--- a/src/server/gc_worker/mod.rs
+++ b/src/server/gc_worker/mod.rs
@@ -12,7 +12,9 @@ pub use compaction_filter::WriteCompactionFilterFactory;
 pub use config::{GcConfig, GcWorkerConfigManager, DEFAULT_GC_BATCH_KEYS};
 use engine_traits::MvccProperties;
 pub use gc_manager::AutoGcConfig;
-pub use gc_worker::{sync_gc, GcSafePointProvider, GcTask, GcWorker, GC_MAX_EXECUTING_TASKS};
+pub use gc_worker::{
+    sync_gc, GcSafePointProvider, GcTask, GcWorker, WithUserSafePoint, GC_MAX_EXECUTING_TASKS,
+};
 use txn_types::TimeStamp;
 
 #[cfg(any(test, feature = "failpoints"))]


### PR DESCRIPTION
This PR made a new `SafePointProvider` wrapper. Which receives an extra "user safe point", and emit the smaller(safer) safe point.

With this provider, we can stall GC via add a `log_backup_safe_point`, which equals to the current `next_backup_ts` of the store.

### Problems 

NOTE: The problem is, when there isn't any task, or there is no writing in the task range, the `next_backup_ts` won't be advanced, hence the GC safe point cannot be advanced too.

NOTE': The `next_backup_ts` may go back when leader transforming. Then the safe point may become unsafe.

(Maybe use the service safe point provided by PD?)