### PR TITLE
br-stream: use raft router to apply kv files for sst_importer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=br-stream#3c677934c5559600d54b4a509ece8d81a6427684"
+source = "git+https://github.com/pingcap/kvproto.git?branch=br-stream#bc0822b00b1d0f3e52d5993ff28151a3d94839c3"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/br-stream/src/endpoint.rs
+++ b/components/br-stream/src/endpoint.rs
@@ -140,7 +140,7 @@ where
     async fn starts_flush_ticks(router: Router) {
         let ticker = tick(Duration::from_secs(FLUSH_STORAGE_INTERVAL / 5));
         loop {
-            // wait 10s to trigger tick
+            // wait 1min to trigger tick
             let _ = ticker.recv().unwrap();
             debug!("backup stream trigger flush tick");
             router.tick().await;

--- a/components/br-stream/src/event_loader.rs
+++ b/components/br-stream/src/event_loader.rs
@@ -112,6 +112,7 @@ impl<S: Snapshot> EventLoader<S> {
 /// Like [`cdc::Initializer`], but supports initialize over range.
 /// Note: maybe we can merge those two structures?
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct InitialDataLoader<E, R, RT> {
     router: RT,
     regions: R,

--- a/components/br-stream/src/lib.rs
+++ b/components/br-stream/src/lib.rs
@@ -1,5 +1,4 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
-#![feature(inherent_ascii_escape)]
 pub mod config;
 mod endpoint;
 pub mod errors;

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -355,7 +355,7 @@ impl RouterInner {
     }
 
     pub async fn unregister_task(&self, task_name: &str) {
-        if let Some(_) = self.tasks.lock().await.remove(task_name) {
+        if self.tasks.lock().await.remove(task_name).is_some() {
             info!(
                 "backup stream unregister task";
                 "task" => task_name,
@@ -985,6 +985,7 @@ impl std::fmt::Debug for DataFile {
 struct KeyRange(Vec<u8>);
 
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 struct TaskRange {
     end: Vec<u8>,
     task_name: String,

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -985,6 +985,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
         // Import SST service.
         let import_service = ImportSSTService::new(
             self.config.import.clone(),
+            self.config.raft_store.raft_entry_max_size,
             self.router.clone(),
             engines.engines.kv.clone(),
             servers.importer.clone(),

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -373,6 +373,7 @@ impl Simulator for ServerCluster {
         };
         let import_service = ImportSSTService::new(
             cfg.import.clone(),
+            cfg.raft_store.raft_entry_max_size,
             sim_router.clone(),
             engines.kv.clone(),
             Arc::clone(&importer),

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -28,7 +28,7 @@ use protobuf::Message;
 
 use crate::server::CONFIG_ROCKSDB_GAUGE;
 use raftstore::router::RaftStoreRouter;
-use raftstore::store::{Callback, Config as RaftConfig, RaftCmdExtraOpts, RegionSnapshot};
+use raftstore::store::{Callback, RaftCmdExtraOpts, RegionSnapshot};
 use tikv_util::config::ReadableSize;
 use tikv_util::future::create_stream_with_buffer;
 use tikv_util::future::paired_future_callback;
@@ -69,6 +69,7 @@ where
 {
     pub fn new(
         cfg: Config,
+        raft_entry_max_size: ReadableSize,
         router: Router,
         engine: E,
         importer: Arc<SSTImporter>,
@@ -94,7 +95,7 @@ where
             importer,
             limiter: Limiter::new(f64::INFINITY),
             task_slots: Arc::new(Mutex::new(HashSet::default())),
-            raft_entry_max_size: RaftConfig::default().raft_entry_max_size,
+            raft_entry_max_size,
         }
     }
 
@@ -448,57 +449,47 @@ where
         let context = req.take_context();
         let meta = req.get_meta();
 
-        match importer.do_download_kv_file(meta, req.get_storage_backend(), &limiter) {
-            Ok(temp_file) => {
-                let mut reqs = vec![];
-                let mut cmd_reqs = vec![];
-                let mut build_req_fn = self.build_apply_request(
-                    reqs.as_mut(),
-                    cmd_reqs.as_mut(),
-                    meta.get_is_delete(),
-                    meta.get_cf(),
-                    context.clone(),
-                );
-                match importer.do_apply_kv_file(
-                    meta.get_restore_ts(),
-                    temp_file,
-                    req.get_rewrite_rule(),
-                    &mut build_req_fn,
-                ) {
-                    Ok(range) => {
-                        drop(build_req_fn);
-                        if !reqs.is_empty() {
-                            let cmd = make_request(reqs.as_mut(), context);
-                            cmd_reqs.push(cmd);
-                        }
-                        for cmd in cmd_reqs {
-                            let (cb, future) = paired_future_callback();
-                            match router.send_command(
-                                cmd,
-                                Callback::write(cb),
-                                RaftCmdExtraOpts::default(),
-                            ) {
-                                Ok(_) => futs.push(future),
-                                Err(_e) => {
-                                    let mut import_err = kvproto::import_sstpb::Error::default();
-                                    import_err
-                                        .set_message("failed to send raft command".to_string());
-                                    apply_resp.set_error(import_err);
-                                }
-                            }
-                        }
-                        if let Some(r) = range {
-                            apply_resp.set_range(r);
-                        }
-                    }
+        let result = (|| -> Result<()> {
+            let temp_file =
+                importer.do_download_kv_file(meta, req.get_storage_backend(), &limiter)?;
+            let mut reqs = vec![];
+            let mut cmd_reqs = vec![];
+            let mut build_req_fn = self.build_apply_request(
+                reqs.as_mut(),
+                cmd_reqs.as_mut(),
+                meta.get_is_delete(),
+                meta.get_cf(),
+                context.clone(),
+            );
+            let range = importer.do_apply_kv_file(
+                meta.get_restore_ts(),
+                temp_file,
+                req.get_rewrite_rule(),
+                &mut build_req_fn,
+            )?;
+            drop(build_req_fn);
+            if !reqs.is_empty() {
+                let cmd = make_request(reqs.as_mut(), context);
+                cmd_reqs.push(cmd);
+            }
+            for cmd in cmd_reqs {
+                let (cb, future) = paired_future_callback();
+                match router.send_command(cmd, Callback::write(cb), RaftCmdExtraOpts::default()) {
+                    Ok(_) => futs.push(future),
                     Err(e) => {
-                        apply_resp.set_error(e.into());
+                        let mut import_err = kvproto::import_sstpb::Error::default();
+                        import_err.set_message(format!("failed to send raft command: {}", e));
+                        apply_resp.set_error(import_err);
                     }
                 }
             }
-            Err(e) => {
-                apply_resp.set_error(e.into());
+            if let Some(r) = range {
+                apply_resp.set_range(r);
             }
+            Ok(())
+        })();
+        if let Err(e) = result {
+            apply_resp.set_error(e.into());
         }
 
         let handle_task = async move {
@@ -506,18 +497,14 @@ where
             sst_importer::metrics::IMPORTER_APPLY_DURATION
                 .with_label_values(&["queue"])
                 .observe(start.saturating_elapsed().as_secs_f64());
-            let resp = if !futs.is_empty() {
-                Ok(join_all(futs).await.iter().fold(apply_resp, |mut resp, x| {
-                    if x.is_err() {
-                        let mut import_err = kvproto::import_sstpb::Error::default();
-                        import_err.set_message("failed to complete raft command".to_string());
-                        resp.set_error(import_err);
-                    }
-                    resp
-                }))
-            } else {
-                Ok(apply_resp)
-            };
+            let resp = Ok(join_all(futs).await.iter().fold(apply_resp, |mut resp, x| {
+                if let Err(e) = x {
+                    let mut import_err = kvproto::import_sstpb::Error::default();
+                    import_err.set_message(format!("failed to complete raft command: {}", e));
+                    resp.set_error(import_err);
+                }
+                resp
+            }));
             // Records how long the apply task waits to be scheduled.
             sst_importer::metrics::IMPORTER_APPLY_DURATION
                 .with_label_values(&["finish"])

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -9,6 +9,7 @@ use collections::HashSet;
 use engine_traits::{KvEngine, CF_WRITE};
 use file_system::{set_io_type, IOType};
 use futures::executor::{ThreadPool, ThreadPoolBuilder};
+use futures::future::join_all;
 use futures::sink::SinkExt;
 use futures::stream::TryStreamExt;
 use futures::TryFutureExt;
@@ -23,10 +24,12 @@ use kvproto::import_sstpb::WriteRequest_oneof_chunk as Chunk;
 use kvproto::import_sstpb::*;
 
 use kvproto::raft_cmdpb::*;
+use protobuf::Message;
 
 use crate::server::CONFIG_ROCKSDB_GAUGE;
 use raftstore::router::RaftStoreRouter;
-use raftstore::store::{Callback, RaftCmdExtraOpts, RegionSnapshot};
+use raftstore::store::{Callback, Config as RaftConfig, RaftCmdExtraOpts, RegionSnapshot};
+use tikv_util::config::ReadableSize;
 use tikv_util::future::create_stream_with_buffer;
 use tikv_util::future::paired_future_callback;
 use tikv_util::time::{Instant, Limiter};
@@ -51,6 +54,7 @@ where
     importer: Arc<SSTImporter>,
     limiter: Limiter,
     task_slots: Arc<Mutex<HashSet<PathBuf>>>,
+    raft_entry_max_size: ReadableSize,
 }
 
 pub struct SnapshotResult<E: KvEngine> {
@@ -90,6 +94,7 @@ where
             importer,
             limiter: Limiter::new(f64::INFINITY),
             task_slots: Arc::new(Mutex::new(HashSet::default())),
+            raft_entry_max_size: RaftConfig::default().raft_entry_max_size,
         }
     }
 
@@ -153,6 +158,57 @@ where
             return Some(errorpb);
         }
         None
+    }
+
+    fn build_apply_request<'a, 'b>(
+        &self,
+        reqs: &'a mut Vec<Request>,
+        cmd_reqs: &'a mut Vec<RaftCmdRequest>,
+        is_delete: bool,
+        cf: &'b str,
+        context: Context,
+    ) -> Box<dyn FnMut(Vec<u8>, Vec<u8>) + 'b>
+    where
+        'a: 'b,
+    {
+        let mut req_size = 0_u64;
+        let raft_size = self.raft_entry_max_size.0;
+
+        // use callback to collect kv data.
+        if is_delete {
+            Box::new(move |k: Vec<u8>, _v: Vec<u8>| {
+                let mut req = Request::default();
+                let mut del = DeleteRequest::default();
+                del.set_key(k);
+                del.set_cf(cf.to_string());
+                req.set_cmd_type(CmdType::Delete);
+                req.set_delete(del);
+                req_size += req.compute_size() as u64;
+                reqs.push(req);
+                if req_size > raft_size / 2 {
+                    req_size = 0;
+                    let cmd = make_request(reqs, context.clone());
+                    cmd_reqs.push(cmd);
+                }
+            })
+        } else {
+            Box::new(move |k: Vec<u8>, v: Vec<u8>| {
+                let mut req = Request::default();
+                let mut put = PutRequest::default();
+                put.set_key(k);
+                put.set_value(v);
+                put.set_cf(cf.to_string());
+                req.set_cmd_type(CmdType::Put);
+                req.set_put(put);
+                req_size += req.compute_size() as u64;
+                reqs.push(req);
+                if req_size > raft_size / 2 {
+                    req_size = 0;
+                    let cmd = make_request(reqs, context.clone());
+                    cmd_reqs.push(cmd);
+                }
+            })
+        }
     }
 
     fn ingest_files(
@@ -374,40 +430,96 @@ where
     }
 
     // Downloads KV file and performs key-rewrite then apply kv into this tikv store.
-    fn apply(&mut self, _ctx: RpcContext<'_>, req: ApplyRequest, sink: UnarySink<ApplyResponse>) {
+    fn apply(
+        &mut self,
+        _ctx: RpcContext<'_>,
+        mut req: ApplyRequest,
+        sink: UnarySink<ApplyResponse>,
+    ) {
         let label = "apply";
         let timer = Instant::now_coarse();
         let importer = Arc::clone(&self.importer);
-        let engine = self.engine.clone();
+        let router = self.router.clone();
         let limiter = self.limiter.clone();
         let start = Instant::now();
+
+        let mut futs = vec![];
+        let mut apply_resp = ApplyResponse::default();
+        let context = req.take_context();
+        let meta = req.get_meta();
+
+        match importer.do_download_kv_file(meta, req.get_storage_backend(), &limiter) {
+            Ok(temp_file) => {
+                let mut reqs = vec![];
+                let mut cmd_reqs = vec![];
+                let mut build_req_fn = self.build_apply_request(
+                    reqs.as_mut(),
+                    cmd_reqs.as_mut(),
+                    meta.get_is_delete(),
+                    meta.get_cf(),
+                    context.clone(),
+                );
+                match importer.do_apply_kv_file(
+                    meta.get_restore_ts(),
+                    temp_file,
+                    req.get_rewrite_rule(),
+                    &mut build_req_fn,
+                ) {
+                    Ok(range) => {
+                        drop(build_req_fn);
+                        if !reqs.is_empty() {
+                            let cmd = make_request(reqs.as_mut(), context);
+                            cmd_reqs.push(cmd);
+                        }
+                        for cmd in cmd_reqs {
+                            let (cb, future) = paired_future_callback();
+                            match router.send_command(
+                                cmd,
+                                Callback::write(cb),
+                                RaftCmdExtraOpts::default(),
+                            ) {
+                                Ok(_) => futs.push(future),
+                                Err(_e) => {
+                                    let mut import_err = kvproto::import_sstpb::Error::default();
+                                    import_err
+                                        .set_message("failed to send raft command".to_string());
+                                    apply_resp.set_error(import_err);
+                                }
+                            }
+                        }
+                        if let Some(r) = range {
+                            apply_resp.set_range(r);
+                        }
+                    }
+                    Err(e) => {
+                        apply_resp.set_error(e.into());
+                    }
+                }
+            }
+            Err(e) => {
+                apply_resp.set_error(e.into());
+            }
+        }
 
         let handle_task = async move {
             // Records how long the apply task waits to be scheduled.
             sst_importer::metrics::IMPORTER_APPLY_DURATION
                 .with_label_values(&["queue"])
                 .observe(start.saturating_elapsed().as_secs_f64());
-
-            let res = importer.apply::<E>(
-                req.get_meta(),
-                req.get_storage_backend(),
-                req.get_rewrite_rule(),
-                limiter,
-                engine,
-            );
-            let mut resp = ApplyResponse::default();
-            match res {
-                Ok(range) => {
-                    if let Some(r) = range {
-                        resp.set_range(r);
+            let resp = if !futs.is_empty() {
+                Ok(join_all(futs).await.iter().fold(apply_resp, |mut resp, x| {
+                    if x.is_err() {
+                        let mut import_err = kvproto::import_sstpb::Error::default();
+                        import_err.set_message("failed to complete raft command".to_string());
+                        resp.set_error(import_err);
                     }
-                }
-                Err(e) => resp.set_error(e.into()),
-            }
-            let resp = Ok(resp);
+                    resp
+                }))
+            } else {
+                Ok(apply_resp)
+            };
             crate::send_rpc_response!(resp, sink, label, timer);
         };
-
         self.threads.spawn_ok(handle_task);
     }
 
@@ -746,4 +858,12 @@ fn make_request_header(mut context: Context) -> RaftRequestHeader {
     header.set_region_id(region_id);
     header.set_region_epoch(context.take_region_epoch());
     header
+}
+
+fn make_request(reqs: &mut Vec<Request>, context: Context) -> RaftCmdRequest {
+    let mut cmd = RaftCmdRequest::default();
+    let header = make_request_header(context);
+    cmd.set_header(header);
+    cmd.set_requests(reqs.drain(..).collect());
+    cmd
 }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -518,6 +518,11 @@ where
             } else {
                 Ok(apply_resp)
             };
+            // Records how long the apply task waits to be scheduled.
+            sst_importer::metrics::IMPORTER_APPLY_DURATION
+                .with_label_values(&["finish"])
+                .observe(start.saturating_elapsed().as_secs_f64());
+            debug!("finished apply kv file with {:?}", resp);
             crate::send_rpc_response!(resp, sink, label, timer);
         };
         self.threads.spawn_ok(handle_task);

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -856,6 +856,6 @@ fn make_request(reqs: &mut Vec<Request>, context: Context) -> RaftCmdRequest {
     let mut cmd = RaftCmdRequest::default();
     let header = make_request_header(context);
     cmd.set_header(header);
-    cmd.set_requests(reqs.drain(..).collect());
+    cmd.set_requests(std::mem::take(reqs).into());
     cmd
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->

What's Changed:
Use raft router to apply kv changed file instead of engine.
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
```
br-stream: use raft router to apply kv files for sst_importer
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. create table and do a full backup
2. starts log backup with tpcc bench
3. check the data
![image](https://user-images.githubusercontent.com/5906259/155469588-fa9d2e71-c0c5-404c-8f20-311c3a585c9b.png)
4. do a full restore and log restore with this PR
5. check the data
![image](https://user-images.githubusercontent.com/5906259/155469789-f318579c-60b4-4b35-b278-619e87b3510d.png)
6. check the log
`[2022/02/24 14:24:26.757 +08:00] [DEBUG] [sst_service.rs:525] ["finished apply kv file with Ok(range { start: 7480000000000000FFAC5F720380000000FF0000000103800000FF0000000001038000FF0000000000010000FDFA0358980EEBFFFE end: 7480000000000000FFAC5F720380000000FF0000000103800000FF000000000A038000FF000000000BB80000FDFA0358992F2FFFFE })"]`

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
