### PR TITLE
don't hold lock during flushing

### DIFF
--- a/components/br-stream/src/endpoint.rs
+++ b/components/br-stream/src/endpoint.rs
@@ -190,6 +190,9 @@ where
 
         let kvs = ApplyEvents::from_cmd_batch(batch, resolver.value_mut());
         drop(resolver);
+        if kvs.len() == 0 {
+            return;
+        }
 
         HANDLE_EVENT_DURATION_HISTOGRAM
             .with_label_values(&["to_stream_event"])

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -422,7 +422,8 @@ impl RouterInner {
     /// returns `None` if failed.
     pub async fn do_flush(&self, task_name: &str, store_id: u64) -> Option<u64> {
         debug!("backup stream do flush"; "task" => task_name);
-        match self.tasks.lock().await.get(task_name) {
+        let task = self.tasks.lock().await.get(task_name).cloned();
+        match task {
             Some(task_info) => {
                 let result = task_info.do_flush(store_id).await;
                 if let Err(ref e) = result {


### PR DESCRIPTION
Currently, we hold the `tasks` mutex during the whole procedure of flushing, but the mutex must be retained by each time we save the event to local file. This made a long tail of consuming batch:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/36239017/155945575-2a1f9228-5da0-47c1-aadf-adca8284a9e7.png">

We should release the lock sooner for eliding that. This is effective according to the test result:

<img width="925" alt="image" src="https://user-images.githubusercontent.com/36239017/155946128-76488bb9-feda-4037-ad88-c8702013c9d3.png">

This PR also skips the whole event when the event is empty (Maybe only operations on Lock CF), which is more frequent than expected (The log only contains 5 mins of events):

```console
root@tikvs:/tidb-deploy/tikv-20160/log# cat tikv.log | grep 'the apply events' | grep 'len=0' |  wc -l
323499
```

NOTE: The time cost of flushing is a little longer than expected... (Averagely ~30s)

```shell
[2022/02/28 15:33:37.131 +08:00] [INFO] [endpoint.rs:386] ["flushing and refreshing checkpoint ts."] [checkpoint_ts=431497828298129485]
[2022/02/28 15:37:08.984 +08:00] [INFO] [router.rs:401] ["try flushing task"] [size=134225043] [task=test2]
[2022/02/28 15:37:43.754 +08:00] [INFO] [router.rs:822] ["flush done"] [cost=34.768s]
[2022/02/28 15:37:43.754 +08:00] [INFO] [endpoint.rs:386] ["flushing and refreshing checkpoint ts."] [checkpoint_ts=431497891763191864]
[2022/02/28 15:41:17.751 +08:00] [INFO] [router.rs:401] ["try flushing task"] [size=134218417] [task=test2]
[2022/02/28 15:41:50.731 +08:00] [INFO] [router.rs:822] ["flush done"] [cost=32.981s]
[2022/02/28 15:41:50.731 +08:00] [INFO] [endpoint.rs:386] ["flushing and refreshing checkpoint ts."] [checkpoint_ts=431497956840439886]
[2022/02/28 15:45:31.012 +08:00] [INFO] [router.rs:401] ["try flushing task"] [size=134218065] [task=test2]
[2022/02/28 15:46:05.932 +08:00] [INFO] [router.rs:822] ["flush done"] [cost=34.917s]
[2022/02/28 15:46:05.933 +08:00] [INFO] [endpoint.rs:386] ["flushing and refreshing checkpoint ts."] [checkpoint_ts=431498023372587109
```