### PR TITLE
use local thread pool for downloading

### DIFF
--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -167,7 +167,7 @@ where
     // in https://github.com/tikv/tikv/blob/a401f78bc86f7e6ea6a55ad9f453ae31be835b55/components/resolved_ts/src/cmd.rs#L204
     // will panic if found duplicated entry during Vec<PutRequest>.
     fn build_apply_request<'a, 'b>(
-        &self,
+        raft_size: u64,
         reqs: &'a mut HashMap<Vec<u8>, Request>,
         cmd_reqs: &'a mut Vec<RaftCmdRequest>,
         is_delete: bool,
@@ -178,7 +178,6 @@ where
         'a: 'b,
     {
         let mut req_size = 0_u64;
-        let raft_size = self.raft_entry_max_size.0;
 
         // use callback to collect kv data.
         if is_delete {
@@ -451,58 +450,61 @@ where
         let router = self.router.clone();
         let limiter = self.limiter.clone();
         let start = Instant::now();
-
-        let mut futs = vec![];
-        let mut apply_resp = ApplyResponse::default();
-        let context = req.take_context();
-        let meta = req.get_meta();
-
-        let result = (|| -> Result<()> {
-            let temp_file =
-                importer.do_download_kv_file(meta, req.get_storage_backend(), &limiter)?;
-            let mut reqs = HashMap::<Vec<u8>, Request>::default();
-            let mut cmd_reqs = vec![];
-            let mut build_req_fn = self.build_apply_request(
-                &mut reqs,
-                cmd_reqs.as_mut(),
-                meta.get_is_delete(),
-                meta.get_cf(),
-                context.clone(),
-            );
-            let range = importer.do_apply_kv_file(
-                meta.get_start_key(),
-                meta.get_end_key(),
-                meta.get_restore_ts(),
-                temp_file,
-                req.get_rewrite_rule(),
-                &mut build_req_fn,
-            )?;
-            drop(build_req_fn);
-            if !reqs.is_empty() {
-                let cmd = make_request(&mut reqs, context);
-                cmd_reqs.push(cmd);
-            }
-            for cmd in cmd_reqs {
-                let (cb, future) = paired_future_callback();
-                match router.send_command(cmd, Callback::write(cb), RaftCmdExtraOpts::default()) {
-                    Ok(_) => futs.push(future),
-                    Err(e) => {
-                        let mut import_err = kvproto::import_sstpb::Error::default();
-                        import_err.set_message(format!("failed to send raft command: {}", e));
-                        apply_resp.set_error(import_err);
-                    }
-                }
-            }
-            if let Some(r) = range {
-                apply_resp.set_range(r);
-            }
-            Ok(())
-        })();
-        if let Err(e) = result {
-            apply_resp.set_error(e.into());
-        }
+        let raft_size = self.raft_entry_max_size;
 
         let handle_task = async move {
+            let mut futs = vec![];
+            let mut apply_resp = ApplyResponse::default();
+            let context = req.take_context();
+            let meta = req.get_meta();
+
+            let result = (|| -> Result<()> {
+                let temp_file =
+                    importer.do_download_kv_file(meta, req.get_storage_backend(), &limiter)?;
+                let mut reqs = HashMap::<Vec<u8>, Request>::default();
+                let mut cmd_reqs = vec![];
+                let mut build_req_fn = Self::build_apply_request(
+                    raft_size.0,
+                    &mut reqs,
+                    cmd_reqs.as_mut(),
+                    meta.get_is_delete(),
+                    meta.get_cf(),
+                    context.clone(),
+                );
+                let range = importer.do_apply_kv_file(
+                    meta.get_start_key(),
+                    meta.get_end_key(),
+                    meta.get_restore_ts(),
+                    temp_file,
+                    req.get_rewrite_rule(),
+                    &mut build_req_fn,
+                )?;
+                drop(build_req_fn);
+                if !reqs.is_empty() {
+                    let cmd = make_request(&mut reqs, context);
+                    cmd_reqs.push(cmd);
+                }
+                for cmd in cmd_reqs {
+                    let (cb, future) = paired_future_callback();
+                    match router.send_command(cmd, Callback::write(cb), RaftCmdExtraOpts::default())
+                    {
+                        Ok(_) => futs.push(future),
+                        Err(e) => {
+                            let mut import_err = kvproto::import_sstpb::Error::default();
+                            import_err.set_message(format!("failed to send raft command: {}", e));
+                            apply_resp.set_error(import_err);
+                        }
+                    }
+                }
+                if let Some(r) = range {
+                    apply_resp.set_range(r);
+                }
+                Ok(())
+            })();
+            if let Err(e) = result {
+                apply_resp.set_error(e.into());
+            }
+
             // Records how long the apply task waits to be scheduled.
             sst_importer::metrics::IMPORTER_APPLY_DURATION
                 .with_label_values(&["queue"])

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -511,10 +511,22 @@ where
             }
 
             let resp = Ok(join_all(futs).await.iter().fold(apply_resp, |mut resp, x| {
-                if let Err(e) = x {
-                    let mut import_err = kvproto::import_sstpb::Error::default();
-                    import_err.set_message(format!("failed to complete raft command: {}", e));
-                    resp.set_error(import_err);
+                match x {
+                    Err(e) => {
+                        let mut import_err = kvproto::import_sstpb::Error::default();
+                        import_err.set_message(format!("failed to complete raft command: {}", e));
+                        resp.set_error(import_err);
+                    }
+                    Ok(r) => {
+                        if r.response.get_header().has_error() {
+                            let mut import_err = kvproto::import_sstpb::Error::default();
+                            let err = r.response.get_header().get_error();
+                            import_err
+                                .set_message(format!("failed to complete raft command: {:?}", err));
+                            warn!("failed to apply the file to the store"; "error" => ?err, "file" => %meta.get_name());
+                            resp.set_error(import_err);
+                        }
+                    }
                 }
                 resp
             }));

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -453,6 +453,11 @@ where
         let raft_size = self.raft_entry_max_size;
 
         let handle_task = async move {
+            // Records how long the apply task waits to be scheduled.
+            sst_importer::metrics::IMPORTER_APPLY_DURATION
+                .with_label_values(&["queue"])
+                .observe(start.saturating_elapsed().as_secs_f64());
+
             let mut futs = vec![];
             let mut apply_resp = ApplyResponse::default();
             let context = req.take_context();
@@ -505,10 +510,6 @@ where
                 apply_resp.set_error(e.into());
             }
 
-            // Records how long the apply task waits to be scheduled.
-            sst_importer::metrics::IMPORTER_APPLY_DURATION
-                .with_label_values(&["queue"])
-                .observe(start.saturating_elapsed().as_secs_f64());
             let resp = Ok(join_all(futs).await.iter().fold(apply_resp, |mut resp, x| {
                 if let Err(e) = x {
                     let mut import_err = kvproto::import_sstpb::Error::default();


### PR DESCRIPTION
We used the gRPC thread pool for downloading files (which is a blocking call), this would probably block the gRPC thread pool and causing gRPC timed out. 

This PR move them to the local thread pool of the importer for downloading.