### PR TITLE
Scan on Leader Change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,7 @@ dependencies = [
  "tikv_util",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.0",
  "txn_types",
  "uuid",
 ]
@@ -1541,7 +1542,7 @@ dependencies = [
  "tikv_alloc",
  "tikv_util",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.6",
  "url",
 ]
 
@@ -1581,7 +1582,7 @@ dependencies = [
  "tempfile",
  "tikv_util",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.6",
  "url",
 ]
 
@@ -2115,7 +2116,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.6",
  "tracing",
 ]
 
@@ -6101,6 +6102,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6132,7 +6148,7 @@ dependencies = [
  "prost-derive 0.8.0",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.6",
  "tower",
  "tower-layer",
  "tower-service",
@@ -6166,7 +6182,7 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.6",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/components/br-stream/Cargo.toml
+++ b/components/br-stream/Cargo.toml
@@ -15,6 +15,7 @@ test-engines-rocksdb = [
 
 [dependencies]
 tokio = { version = "1.5", features = ["rt-multi-thread", "macros", "time", "sync"] }
+tokio-util = { version = "0.7", features = ["compat"] } 
 prometheus = { version = "0.13", default-features = false, features = ["nightly"] }
 async-trait = { version = "0.1" }
 thiserror = "1"

--- a/components/br-stream/src/endpoint.rs
+++ b/components/br-stream/src/endpoint.rs
@@ -463,7 +463,7 @@ where
 
             match init.do_initial_scan(&region, TimeStamp::new(from_ts), snap) {
                 Ok(stat) => {
-                    info!("initial scanning of leader transforming finished!"; "statistics" => ?stat, "region" => %region.get_id());
+                    info!("initial scanning of leader transforming finished!"; "statistics" => ?stat, "region" => %region.get_id(), "from_ts" => %from_ts);
                 }
                 Err(err) => err.report(format!("during initial scanning of region {:?}", region)),
             }

--- a/components/br-stream/src/endpoint.rs
+++ b/components/br-stream/src/endpoint.rs
@@ -408,7 +408,7 @@ where
         //       if the server crashes immediately, and data of this scanning hasn't been sent to sink,
         //       those data would be permanently lost.
         // Maybe we need block the next_backup_ts from advancing before all initial scanning done(Or just for the region, via disabling the resolver)?
-        tokio::task::spawn_blocking(move || {
+        self.pool.spawn_blocking(move || {
             let from_ts = match block_on(meta_cli.global_progress_of_task(&task)) {
                 Ok(ts) => ts,
                 Err(err) => {

--- a/components/br-stream/src/event_loader.rs
+++ b/components/br-stream/src/event_loader.rs
@@ -178,16 +178,12 @@ where
         Ok(snap)
     }
 
-    /// Initialize the region: register it to the raftstore and the observer.
-    /// At the same time, perform the initial scanning, (an incremental scanning from `start_ts`)
-    /// and generate the corresponding ApplyEvent to the sink directly.
-    pub fn initialize_region(
+    pub fn do_initial_scan(
         &self,
         region: &Region,
         start_ts: TimeStamp,
-        cmd: ChangeObserver,
+        snap: impl Snapshot,
     ) -> Result<Statistics> {
-        let snap = self.observe_over(region, cmd)?;
         // It is ok to sink more data than needed. So scan to +inf TS for convenance.
         let mut event_loader = EventLoader::load_from(snap, start_ts, TimeStamp::max(), region)?;
         let mut stats = StatisticsSummary::default();
@@ -208,6 +204,19 @@ where
             });
         }
         Ok(stats.stat)
+    }
+
+    /// Initialize the region: register it to the raftstore and the observer.
+    /// At the same time, perform the initial scanning, (an incremental scanning from `start_ts`)
+    /// and generate the corresponding ApplyEvent to the sink directly.
+    pub fn initialize_region(
+        &self,
+        region: &Region,
+        start_ts: TimeStamp,
+        cmd: ChangeObserver,
+    ) -> Result<Statistics> {
+        let snap = self.observe_over(region, cmd)?;
+        self.do_initial_scan(region, start_ts, snap)
     }
 
     /// initialize a range: it simply scan the regions with leader role and send them to [`initialize_region`].

--- a/components/br-stream/src/metadata/client.rs
+++ b/components/br-stream/src/metadata/client.rs
@@ -12,7 +12,7 @@ use kvproto::brpb::StreamBackupTaskInfo;
 
 use tikv_util::{defer, time::Instant, warn};
 use tokio_stream::StreamExt;
-use txn_types::TimeStamp;
+
 
 use crate::errors::{Error, Result};
 
@@ -285,7 +285,7 @@ impl<Store: MetaStore> MetadataClient<Store> {
             .iter()
             .filter_map(|kv| {
                 Self::parse_ts_from_bytes(kv.1.as_slice())
-                    .map_err(|err| warn!("failed to parse next_backup_ts."; "key" => ?kv.0, "err" => %err))
+                    .map_err(|err| warn!("br-stream: failed to parse next_backup_ts."; "key" => ?kv.0, "err" => %err))
                     .ok()
             })
             .min()

--- a/components/br-stream/src/metadata/client.rs
+++ b/components/br-stream/src/metadata/client.rs
@@ -10,8 +10,9 @@ use super::{
 
 use kvproto::brpb::StreamBackupTaskInfo;
 
-use tikv_util::{defer, time::Instant};
+use tikv_util::{defer, time::Instant, warn};
 use tokio_stream::StreamExt;
+use txn_types::TimeStamp;
 
 use crate::errors::{Error, Result};
 
@@ -257,7 +258,7 @@ impl<Store: MetaStore> MetadataClient<Store> {
         }
         let task = self.get_task(task_name).await?;
         let timestamp = self.meta_store.snapshot().await?;
-        let mut items = timestamp
+        let items = timestamp
             .get(Keys::Key(MetaKey::next_backup_ts_of(
                 task_name,
                 self.store_id,
@@ -266,18 +267,42 @@ impl<Store: MetaStore> MetadataClient<Store> {
         if items.is_empty() {
             Ok(task.info.start_ts)
         } else {
-            assert!(items.len() == 1, "{:?}", items);
-            let next_backup_ts = std::mem::take(&mut items[0].1);
-            if next_backup_ts.len() != 8 {
-                return Err(Error::MalformedMetadata(format!(
-                    "the length of next_backup_ts is {} bytes, require 8 bytes",
-                    next_backup_ts.len()
-                )));
-            }
-            let mut buf = [0u8; 8];
-            buf.copy_from_slice(next_backup_ts.as_slice());
-            Ok(u64::from_be_bytes(buf))
+            assert_eq!(items.len(), 1);
+            Self::parse_ts_from_bytes(items[0].1.as_slice())
         }
+    }
+
+    /// get the global progress (the min next_backup_ts among all stores).
+    pub async fn global_progress_of_task(&self, task_name: &str) -> Result<u64> {
+        let now = Instant::now();
+        defer! {
+            super::metrics::METADATA_OPERATION_LATENCY.with_label_values(&["task_progress_get_global"]).observe(now.saturating_elapsed().as_secs_f64())
+        }
+        let task = self.get_task(task_name).await?;
+        let snap = self.meta_store.snapshot().await?;
+        let global_ts = snap.get(Keys::Prefix(MetaKey::next_backup_ts(task_name)))
+            .await?
+            .iter()
+            .filter_map(|kv| {
+                Self::parse_ts_from_bytes(kv.1.as_slice())
+                    .map_err(|err| warn!("failed to parse next_backup_ts."; "key" => ?kv.0, "err" => %err))
+                    .ok()
+            })
+            .min()
+            .unwrap_or(task.info.start_ts);
+        Ok(global_ts)
+    }
+
+    fn parse_ts_from_bytes(next_backup_ts: &[u8]) -> Result<u64> {
+        if next_backup_ts.len() != 8 {
+            return Err(Error::MalformedMetadata(format!(
+                "the length of next_backup_ts is {} bytes, require 8 bytes",
+                next_backup_ts.len()
+            )));
+        }
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(next_backup_ts);
+        Ok(u64::from_be_bytes(buf))
     }
 
     /// insert a task with ranges into the metadata store.

--- a/components/br-stream/src/metadata/keys.rs
+++ b/components/br-stream/src/metadata/keys.rs
@@ -99,11 +99,15 @@ impl MetaKey {
 
     /// The key of next backup ts of some region in some store.
     pub fn next_backup_ts_of(name: &str, store_id: u64) -> Self {
-        let base = format!("{}{}/{}", PREFIX, PATH_NEXT_BACKUP_TS, name);
-        let mut buf = bytes::BytesMut::from(base);
-        buf.put(b'/');
+        let base = Self::next_backup_ts(name);
+        let mut buf = bytes::BytesMut::from(base.0);
         buf.put_u64_be(store_id);
         Self(buf.to_vec())
+    }
+
+    // The prefix for next backup ts.
+    pub fn next_backup_ts(name: &str) -> Self {
+        Self(format!("{}{}/{}/", PREFIX, PATH_NEXT_BACKUP_TS, name).into_bytes())
     }
 
     /// The key for pausing some task.

--- a/components/br-stream/src/metrics.rs
+++ b/components/br-stream/src/metrics.rs
@@ -57,6 +57,7 @@ lazy_static! {
         "tikv_stream_flush_duration_sec",
         "The time cost of flushing a task.",
         &["stage"],
+        exponential_buckets(0.001, 2.0, 16).unwrap()
     )
     .unwrap();
 }

--- a/components/br-stream/src/metrics.rs
+++ b/components/br-stream/src/metrics.rs
@@ -53,4 +53,10 @@ lazy_static! {
         &["task"],
     )
     .unwrap();
+    pub static ref FLUSH_DURATION: HistogramVec = register_histogram_vec!(
+        "tikv_stream_flush_duration_sec",
+        "The time cost of flushing a task.",
+        &["stage"],
+    )
+    .unwrap();
 }

--- a/components/br-stream/src/observer.rs
+++ b/components/br-stream/src/observer.rs
@@ -57,6 +57,7 @@ impl BackupStreamObserver {
             .scheduler
             .schedule(Task::ModifyObserve(ObserveOp::Start {
                 region: region.clone(),
+                needs_initial_scanning: true,
             }))
         {
             Error::from(err).report(format_args!(

--- a/components/br-stream/src/observer.rs
+++ b/components/br-stream/src/observer.rs
@@ -273,7 +273,7 @@ mod tests {
         o.register_region(&r);
         let task = rx.recv_timeout(Duration::from_secs(0)).unwrap().unwrap();
         let handle = ObserveHandle::new();
-        if let Task::ModifyObserve(ObserveOp::Start { region }) = task {
+        if let Task::ModifyObserve(ObserveOp::Start { region, .. }) = task {
             o.subs.register_region(region.get_id(), handle.clone())
         } else {
             panic!("unexpected message received: it is {}", task);
@@ -297,7 +297,7 @@ mod tests {
         o.register_region(&r);
         let task = rx.recv_timeout(Duration::from_secs(0)).unwrap().unwrap();
         let handle = ObserveHandle::new();
-        assert_matches!(task, Task::ModifyObserve(ObserveOp::Start { region }) => {
+        assert_matches!(task, Task::ModifyObserve(ObserveOp::Start { region, .. }) => {
             o.subs.register_region(region.get_id(), handle.clone())
         });
 

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -305,8 +305,14 @@ impl RouterInner {
         }
     }
 
-    pub fn find_task_by_range(&self, start_key: &[u8], end_key: &[u8]) -> Option<String> {
+    /// Find the task for a region. If `end_key` is empty, search from start_key to +inf.
+    /// It simply search for a random possible overlapping range and get its task.
+    /// FIXME: If a region crosses many tasks, this can only find one of them.
+    pub fn find_task_by_range(&self, start_key: &[u8], mut end_key: &[u8]) -> Option<String> {
         let r = self.ranges.rl();
+        if end_key.is_empty() {
+            end_key = &[0xffu8; 32];
+        }
         r.find_overlapping((start_key, end_key))
             .map(|x| x.2.clone())
     }

--- a/components/br-stream/src/router.rs
+++ b/components/br-stream/src/router.rs
@@ -305,6 +305,12 @@ impl RouterInner {
         }
     }
 
+    pub fn find_task_by_range(&self, start_key: &[u8], end_key: &[u8]) -> Option<String> {
+        let r = self.ranges.rl();
+        r.find_overlapping((start_key, end_key))
+            .map(|x| x.2.clone())
+    }
+
     /// Register some ranges associated to some task.
     /// Because the observer interface yields encoded data key, the key should be ENCODED DATA KEY too.    
     /// (i.e. encoded by `Key::from_raw(key).into_encoded()`, [`utils::wrap_key`] could be a shortcut.).    

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -162,7 +162,7 @@ where
     }
 
     fn build_apply_request<'a, 'b>(
-        &self,
+        raft_size: u64,
         reqs: &'a mut Vec<Request>,
         cmd_reqs: &'a mut Vec<RaftCmdRequest>,
         is_delete: bool,
@@ -173,7 +173,6 @@ where
         'a: 'b,
     {
         let mut req_size = 0_u64;
-        let raft_size = self.raft_entry_max_size.0;
 
         // use callback to collect kv data.
         if is_delete {
@@ -443,56 +442,58 @@ where
         let router = self.router.clone();
         let limiter = self.limiter.clone();
         let start = Instant::now();
-
-        let mut futs = vec![];
-        let mut apply_resp = ApplyResponse::default();
-        let context = req.take_context();
-        let meta = req.get_meta();
-
-        let result = (|| -> Result<()> {
-            let temp_file =
-                importer.do_download_kv_file(meta, req.get_storage_backend(), &limiter)?;
-            let mut reqs = vec![];
-            let mut cmd_reqs = vec![];
-            let mut build_req_fn = self.build_apply_request(
-                reqs.as_mut(),
-                cmd_reqs.as_mut(),
-                meta.get_is_delete(),
-                meta.get_cf(),
-                context.clone(),
-            );
-            let range = importer.do_apply_kv_file(
-                meta.get_restore_ts(),
-                temp_file,
-                req.get_rewrite_rule(),
-                &mut build_req_fn,
-            )?;
-            drop(build_req_fn);
-            if !reqs.is_empty() {
-                let cmd = make_request(reqs.as_mut(), context);
-                cmd_reqs.push(cmd);
-            }
-            for cmd in cmd_reqs {
-                let (cb, future) = paired_future_callback();
-                match router.send_command(cmd, Callback::write(cb), RaftCmdExtraOpts::default()) {
-                    Ok(_) => futs.push(future),
-                    Err(e) => {
-                        let mut import_err = kvproto::import_sstpb::Error::default();
-                        import_err.set_message(format!("failed to send raft command: {}", e));
-                        apply_resp.set_error(import_err);
-                    }
-                }
-            }
-            if let Some(r) = range {
-                apply_resp.set_range(r);
-            }
-            Ok(())
-        })();
-        if let Err(e) = result {
-            apply_resp.set_error(e.into());
-        }
+        let raft_size = self.raft_entry_max_size.0;
 
         let handle_task = async move {
+            let mut futs = vec![];
+            let mut apply_resp = ApplyResponse::default();
+            let context = req.take_context();
+            let meta = req.get_meta();
+
+            let result = (|| -> Result<()> {
+                let temp_file =
+                    importer.do_download_kv_file(meta, req.get_storage_backend(), &limiter)?;
+                let mut reqs = vec![];
+                let mut cmd_reqs = vec![];
+                let mut build_req_fn = Self::build_apply_request(
+                    raft_size,
+                    reqs.as_mut(),
+                    cmd_reqs.as_mut(),
+                    meta.get_is_delete(),
+                    meta.get_cf(),
+                    context.clone(),
+                );
+                let range = importer.do_apply_kv_file(
+                    meta.get_restore_ts(),
+                    temp_file,
+                    req.get_rewrite_rule(),
+                    &mut build_req_fn,
+                )?;
+                drop(build_req_fn);
+                if !reqs.is_empty() {
+                    let cmd = make_request(reqs.as_mut(), context);
+                    cmd_reqs.push(cmd);
+                }
+                for cmd in cmd_reqs {
+                    let (cb, future) = paired_future_callback();
+                    match router.send_command(cmd, Callback::write(cb), RaftCmdExtraOpts::default())
+                    {
+                        Ok(_) => futs.push(future),
+                        Err(e) => {
+                            let mut import_err = kvproto::import_sstpb::Error::default();
+                            import_err.set_message(format!("failed to send raft command: {}", e));
+                            apply_resp.set_error(import_err);
+                        }
+                    }
+                }
+                if let Some(r) = range {
+                    apply_resp.set_range(r);
+                }
+                Ok(())
+            })();
+            if let Err(err) = result {
+                apply_resp.set_error(err.into());
+            }
             // Records how long the apply task waits to be scheduled.
             sst_importer::metrics::IMPORTER_APPLY_DURATION
                 .with_label_values(&["queue"])


### PR DESCRIPTION
This PR added an extra scanning from `[global_checkpoint_ts, now)` when the observer registered to the raftstore.

This is essential because sometimes the follower may apply to greater index than the leader. In this condition, we may lose some of data. 

However, if there are many leadership changing (for example, `shuffle-leader-scheduler` enabled.), we may emit many duplicated backup data, which is a risk.

This PR also make flushing concurrent.