### PR TITLE
Use min ts of mem lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
  "async-trait",
  "bytes 0.4.12",
  "chrono",
+ "concurrency_manager",
  "crossbeam",
  "crossbeam-channel",
  "dashmap",

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -55,6 +55,7 @@ tikv = { path = "../../", default-features = false }
 online_config = { path = "../online_config" }
 resolved_ts = { path = "../resolved_ts"}
 pd_client = {path = "../pd_client"}
+concurrency_manager = { path = "../concurrency_manager"}
 
 [dev-dependencies]
 rand = "0.8.0"

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use concurrency_manager::ConcurrencyManager;
 use dashmap::DashMap;
 use engine_traits::KvEngine;
 
@@ -61,6 +62,7 @@ pub struct Endpoint<S: MetaStore + 'static, R, E, RT, PDC> {
     router: RT,
     pd_client: Arc<PDC>,
     resolvers: Arc<DashMap<u64, Resolver>>,
+    concurrency_manager: ConcurrencyManager,
 }
 
 impl<S, R, E, RT, PDC> Endpoint<S, R, E, RT, PDC>
@@ -140,6 +142,7 @@ where
         accessor: R,
         router: RT,
         pd_client: Arc<PDC>,
+        concurrency_manager: ConcurrencyManager,
     ) -> Endpoint<EtcdStore, R, E, RT, PDC> {
         let pool = create_tokio_runtime(config.num_threads, "backup-stream")
             .expect("failed to create tokio runtime for backup stream worker.");
@@ -190,6 +193,7 @@ where
             router,
             pd_client,
             resolvers: Default::default(),
+            concurrency_manager,
         }
     }
 }
@@ -414,12 +418,18 @@ where
     }
 
     /// try advance the resolved ts by the pd tso.
-    async fn try_resolve(pd_client: Arc<PDC>, resolvers: Arc<DashMap<u64, Resolver>>) -> TimeStamp {
-        let tso = pd_client
+    async fn try_resolve(
+        cm: ConcurrencyManager,
+        pd_client: Arc<PDC>,
+        resolvers: Arc<DashMap<u64, Resolver>>,
+    ) -> TimeStamp {
+        let pd_tso = pd_client
             .get_tso()
             .await
             .map_err(|err| Error::from(err).report("failed to get tso from pd"))
             .unwrap_or_default();
+        let min_ts = cm.global_min_lock_ts().unwrap_or(TimeStamp::max());
+        let tso = Ord::min(pd_tso, min_ts);
         let new_tso = resolvers
             .as_ref()
             .iter_mut()
@@ -436,11 +446,12 @@ where
         pd_cli: Arc<PDC>,
         resolvers: Arc<DashMap<u64, Resolver>>,
         meta_cli: MetadataClient<S>,
+        concurrency_manager: ConcurrencyManager,
     ) {
         let start = Instant::now_coarse();
         // NOTE: Maybe push down the resolve step to the router?
         //       Or if there are too many duplicated `Flush` command, we may do some useless works.
-        let new_rts = Self::try_resolve(pd_cli.clone(), resolvers).await;
+        let new_rts = Self::try_resolve(concurrency_manager, pd_cli.clone(), resolvers).await;
         metrics::FLUSH_DURATION
             .with_label_values(&["resolve_by_now"])
             .observe(start.saturating_elapsed_secs());
@@ -484,11 +495,12 @@ where
             .clone();
         let pd_cli = self.pd_client.clone();
         let resolvers = self.resolvers.clone();
+        let cm = self.concurrency_manager.clone();
         self.pool.spawn(async move {
             let info = router.get_task_info(&task).await;
             // This should only happen in testing, it would be to unwrap...
             let _ = info.unwrap().set_flushing_status_cas(false, true);
-            Self::flush_for_task(task, store_id, router, pd_cli, resolvers, cli).await;
+            Self::flush_for_task(task, store_id, router, pd_cli, resolvers, cli, cm).await;
         });
     }
 
@@ -501,8 +513,9 @@ where
             .clone();
         let pd_cli = self.pd_client.clone();
         let resolvers = self.resolvers.clone();
+        let cm = self.concurrency_manager.clone();
         self.pool.spawn(Self::flush_for_task(
-            task, store_id, router, pd_cli, resolvers, cli,
+            task, store_id, router, pd_cli, resolvers, cli, cm,
         ));
     }
 

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -300,7 +300,6 @@ where
             self.router.clone(),
             self.regions.clone(),
             self.range_router.clone(),
-            self.concurrency_manager.clone(),
         )
     }
 

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -432,7 +432,7 @@ where
             .unwrap_or_default();
         let min_ts = cm.global_min_lock_ts().unwrap_or(TimeStamp::max());
         let tso = Ord::min(pd_tso, min_ts);
-        info!("using tso for resolving"; "min_ts" => %min_ts, "pd_tso" => %pd_tso);
+        info!("backup stream using tso for resolving"; "min_ts" => %min_ts, "pd_tso" => %pd_tso);
         let new_tso = resolvers
             .as_ref()
             .iter_mut()

--- a/components/backup-stream/src/metadata/store/slash_etc.rs
+++ b/components/backup-stream/src/metadata/store/slash_etc.rs
@@ -10,6 +10,7 @@ use crate::{
     },
 };
 use async_trait::async_trait;
+use slog_global::error;
 use std::{
     cell::Cell,
     collections::{BTreeMap, HashMap},
@@ -155,7 +156,7 @@ impl MetaStore for SlashEtcStore {
     ) -> Result<KvChangeSubscription> {
         let mut data = self.lock().await;
         if start_rev != data.revision + 1 {
-            panic!(
+            error!(
                 "start from arbitrary revision is not supported yet; only watch (current_rev + 1) supported. (self.revision = {}; start_rev = {})",
                 data.revision, start_rev
             );

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -132,14 +132,6 @@ impl ApplyEvents {
                 }
                 continue;
             }
-            // use the key ts as min_ts would be safe.
-            // - if it is uncommitted, the lock would be tracked, preventing resolved ts
-            //   advanced incorrectly.
-            // - if it is committed, it is safe(hopefully) to advance resolved ts to it.
-            //   (Will something like one PC break this?)
-            // note: maybe get this ts from PD? The current implement cannot advance the resolved ts
-            //       if there is no write.
-            resolver.resolve(Key::decode_ts_from(&key).unwrap_or_default());
             let item = ApplyEvent {
                 key,
                 value,

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -4,7 +4,6 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    iter::FromIterator,
     path::Path,
     sync::Arc,
 };
@@ -14,10 +13,11 @@ use backup_stream::{
     observer::BackupStreamObserver,
     Endpoint, Task,
 };
-use futures::executor::block_on;
+use futures::{executor::block_on, Future};
 use grpcio::ChannelBuilder;
 use kvproto::{brpb::Local, tikvpb::*};
 use kvproto::{brpb::StorageBackend, kvrpcpb::*};
+use pd_client::PdClient;
 use tempdir::TempDir;
 use test_raftstore::{new_server_cluster, Cluster, ServerCluster};
 use tikv::config::BackupStreamConfig;
@@ -26,6 +26,7 @@ use tikv_util::{
         number::NumberEncoder,
         stream_event::{EventIterator, Iterator},
     },
+    info,
     worker::LazyWorker,
     HandyRwLock,
 };
@@ -121,6 +122,7 @@ impl Suite {
         let worker = self.endpoints.get_mut(&id).unwrap();
         let sim = cluster.sim.wl();
         let raft_router = sim.get_server_router(id);
+        let cm = sim.get_concurrency_manager(id);
         let regions = sim.region_info_accessors.get(&id).unwrap().clone();
         let mut cfg = BackupStreamConfig::default();
         cfg.enable = true;
@@ -135,6 +137,7 @@ impl Suite {
             regions,
             raft_router,
             cluster.pd_client.clone(),
+            cm,
         );
         worker.start(endpoint);
     }
@@ -185,29 +188,41 @@ impl Suite {
         .unwrap();
     }
 
-    fn write_records(&mut self, from: usize, n: usize, for_table: i64) {
+    async fn write_records(&mut self, from: usize, n: usize, for_table: i64) -> HashSet<Vec<u8>> {
+        let mut inserted = HashSet::default();
         for ts in (from..(from + n)).map(|x| x * 2) {
             let ts = ts as u64;
             let key = make_record_key(for_table, ts);
             let muts = vec![mutation(key.clone(), b"hello, world".to_vec())];
             let enc_key = Key::from_raw(&key).into_encoded();
             let region = self.cluster.get_region_id(&enc_key);
-            self.must_kv_prewrite(region, muts, key.clone(), TimeStamp::new(ts));
-            self.must_kv_commit(
-                region,
-                vec![key.clone()],
-                TimeStamp::new(ts),
-                TimeStamp::new(ts + 1),
-            );
+            let start_ts = self.cluster.pd_client.get_tso().await.unwrap();
+            self.must_kv_prewrite(region, muts, key.clone(), start_ts);
+            let commit_ts = self.cluster.pd_client.get_tso().await.unwrap();
+            self.must_kv_commit(region, vec![key.clone()], start_ts, commit_ts);
+            inserted.insert(make_encoded_record_key(
+                for_table,
+                ts,
+                commit_ts.into_inner(),
+            ));
         }
+        inserted
     }
 
-    fn just_async_commit_prewrite(&mut self, ts: u64, for_table: i64) {
+    fn just_commit_a_key(&mut self, key: Vec<u8>, start_ts: TimeStamp, commit_ts: TimeStamp) {
+        let enc_key = Key::from_raw(&key).into_encoded();
+        let region = self.cluster.get_region_id(&enc_key);
+        self.must_kv_commit(region, vec![key], start_ts, commit_ts)
+    }
+
+    fn just_async_commit_prewrite(&mut self, ts: u64, for_table: i64) -> TimeStamp {
         let key = make_record_key(for_table, ts);
         let muts = vec![mutation(key.clone(), b"hello, world".to_vec())];
         let enc_key = Key::from_raw(&key).into_encoded();
         let region = self.cluster.get_region_id(&enc_key);
-        self.must_kv_async_commit_prewrite(region, muts, key, TimeStamp::new(ts));
+        let ts = self.must_kv_async_commit_prewrite(region, muts, key, TimeStamp::new(ts));
+        info!("async prewrite success!"; "min_commit_ts" => %ts);
+        ts
     }
 
     fn force_flush_files(&self, task: &str) {
@@ -219,12 +234,13 @@ impl Suite {
         }
     }
 
-    fn check_for_write_records(&self, n: u64, for_table: i64, path: &Path) {
-        let mut remain_keys: HashSet<Vec<u8>> = HashSet::from_iter(
-            (0..n)
-                .map(|x| x * 2)
-                .map(|n| make_encoded_record_key(for_table, n, n + 1)),
-        );
+    fn check_for_write_records<'a>(
+        &self,
+        path: &Path,
+        key_set: impl std::iter::Iterator<Item = &'a [u8]>,
+    ) {
+        let mut remain_keys = key_set.collect::<HashSet<_>>();
+        let n = remain_keys.len();
         let mut extra_key = 0;
         let mut extra_len = 0;
         for entry in WalkDir::new(path) {
@@ -399,25 +415,39 @@ impl Suite {
     }
 }
 
+fn run_async_test<T>(test: impl Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(test)
+}
+
 mod test {
     use std::time::Duration;
 
     use backup_stream::metadata::MetadataClient;
+    use txn_types::TimeStamp;
 
-    use crate::make_split_key_at_record;
+    use crate::{make_record_key, make_split_key_at_record, run_async_test};
 
     #[test]
     fn basic() {
         test_util::init_log_for_test();
         let mut suite = super::Suite::new("basic", 4);
 
-        // write data before the task starting, for testing incremental scanning.
-        suite.write_records(0, 128, 1);
-        suite.must_register_task(1, "test_basic");
-        suite.write_records(128, 128, 1);
-        suite.force_flush_files("test_basic");
-        std::thread::sleep(Duration::from_secs(4));
-        suite.check_for_write_records(256, 1, suite.flushed_files.path());
+        run_async_test(async {
+            // write data before the task starting, for testing incremental scanning.
+            let round1 = suite.write_records(0, 128, 1).await;
+            suite.must_register_task(1, "test_basic");
+            let round2 = suite.write_records(128, 128, 1).await;
+            suite.force_flush_files("test_basic");
+            std::thread::sleep(Duration::from_secs(4));
+            suite.check_for_write_records(
+                suite.flushed_files.path(),
+                round1.union(&round2).map(Vec::as_slice),
+            );
+        });
         suite.cluster.shutdown();
     }
 
@@ -425,50 +455,69 @@ mod test {
     fn with_split() {
         test_util::init_log_for_test();
         let mut suite = super::Suite::new("with_split", 4);
-        suite.write_records(0, 128, 1);
-        suite.must_split(&make_split_key_at_record(1, 42));
-        suite.must_register_task(1, "test_with_split");
-        suite.write_records(128, 128, 1);
-        suite.force_flush_files("test_with_split");
-        std::thread::sleep(Duration::from_secs(4));
-        suite.check_for_write_records(256, 1, suite.flushed_files.path());
+        run_async_test(async {
+            let round1 = suite.write_records(0, 128, 1).await;
+            suite.must_split(&make_split_key_at_record(1, 42));
+            suite.must_register_task(1, "test_with_split");
+            let round2 = suite.write_records(256, 128, 1).await;
+            suite.force_flush_files("test_with_split");
+            std::thread::sleep(Duration::from_secs(4));
+            suite.check_for_write_records(
+                suite.flushed_files.path(),
+                round1.union(&round2).map(Vec::as_slice),
+            );
+        });
         suite.cluster.shutdown();
     }
 
     #[test]
+    /// This case tests whether the backup can continue when the leader failes.
     fn leader_down() {
         test_util::init_log_for_test();
         let mut suite = super::Suite::new("leader_down", 4);
         suite.must_register_task(1, "test_leader_down");
-
-        suite.write_records(0, 128, 1);
+        let round1 = run_async_test(suite.write_records(0, 128, 1));
         let leader = suite.cluster.leader_of_region(1).unwrap().get_store_id();
         suite.cluster.stop_node(leader);
-        suite.write_records(128, 128, 1);
+        let round2 = run_async_test(suite.write_records(256, 128, 1));
         suite.force_flush_files("test_leader_down");
         std::thread::sleep(Duration::from_secs(4));
-        suite.check_for_write_records(256, 1, suite.flushed_files.path());
+        suite.check_for_write_records(
+            suite.flushed_files.path(),
+            round1.union(&round2).map(Vec::as_slice),
+        );
         suite.cluster.shutdown();
     }
 
-    #[tokio::test]
-    // FIXME: This test case cannot pass for now.
-    async fn async_commit() {
+    #[test]
+    /// This case tests whehter the checkpoint ts (next backup ts) can be advanced correctly
+    /// when async commit is enabled.
+    fn async_commit() {
         test_util::init_log_for_test();
         let mut suite = super::Suite::new("async_commit", 3);
-        suite.must_register_task(1, "test_async_commit");
-
-        suite.write_records(0, 128, 1);
-        suite.just_async_commit_prewrite(128, 1);
-        suite.write_records(130, 128, 1);
-        suite.force_flush_files("test_async_commit");
-        std::thread::sleep(Duration::from_secs(4));
-        let cli = MetadataClient::new(suite.meta_store, 1);
-        assert_eq!(
-            cli.global_progress_of_task("test_async_commit")
+        run_async_test(async {
+            suite.must_register_task(1, "test_async_commit");
+            suite.write_records(0, 128, 1).await;
+            let ts = suite.just_async_commit_prewrite(256, 1);
+            suite.write_records(258, 128, 1).await;
+            suite.force_flush_files("test_async_commit");
+            std::thread::sleep(Duration::from_secs(4));
+            let cli = MetadataClient::new(suite.meta_store.clone(), 1);
+            assert_eq!(
+                cli.global_progress_of_task("test_async_commit")
+                    .await
+                    .unwrap(),
+                256
+            );
+            suite.just_commit_a_key(make_record_key(1, 256), TimeStamp::new(256), ts);
+            suite.force_flush_files("test_async_commit");
+            std::thread::sleep(Duration::from_secs(4));
+            let cp = cli
+                .global_progress_of_task("test_async_commit")
                 .await
-                .unwrap(),
-            128
-        );
+                .unwrap();
+            assert!(cp > 514, "it is {:?}", cp);
+        });
+        suite.cluster.shutdown();
     }
 }

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -440,7 +440,7 @@ mod test {
             // write data before the task starting, for testing incremental scanning.
             let round1 = suite.write_records(0, 128, 1).await;
             suite.must_register_task(1, "test_basic");
-            let round2 = suite.write_records(128, 128, 1).await;
+            let round2 = suite.write_records(256, 128, 1).await;
             suite.force_flush_files("test_basic");
             std::thread::sleep(Duration::from_secs(4));
             suite.check_for_write_records(

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -842,6 +842,7 @@ impl<ER: RaftEngine> TiKVServer<ER> {
                 self.region_info_accessor.clone(),
                 self.router.clone(),
                 self.pd_client.clone(),
+                self.concurrency_manager.clone(),
             );
             backup_stream_worker.start(backup_stream_endpoint);
             self.to_stop.push(backup_stream_worker);


### PR DESCRIPTION
This PR use `min(min_lock_ts_in_memory, pd_tso)` as the checkpoint ts of that region when flushing. This can make the checkpoint ts correct when async commit transactions exist.

This also have updated the `max_ts` in the `concurrency_manager` when flushing flies, which would make sure there wouldn't be any async commit transaction use commit ts less than checkpoint ts.

The integration test case `async_commit` would be fixed after this PR.