### PR TITLE
backup-stream: fix the data loss in upload part of S3 storage

### DIFF
--- a/components/cloud/aws/src/lib.rs
+++ b/components/cloud/aws/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+#![feature(assert_matches)]
 
 mod kms;
 pub use kms::{AwsKms, ENCRYPTION_VENDOR_NAME_AWS_KMS};

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -269,15 +269,15 @@ async fn try_read_exact<R: AsyncRead + ?Sized + Unpin>(
     r: &mut R,
     buf: &mut [u8],
 ) -> io::Result<usize> {
-    let mut size_readed = 0;
+    let mut size_read = 0;
     loop {
-        let r = r.read(&mut buf[size_readed..]).await?;
+        let r = r.read(&mut buf[size_read..]).await?;
         if r == 0 {
-            return Ok(size_readed);
+            return Ok(size_read);
         }
-        size_readed += r;
-        if size_readed >= buf.len() {
-            return Ok(size_readed);
+        size_read += r;
+        if size_read >= buf.len() {
+            return Ok(size_read);
         }
     }
 }

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -262,6 +262,31 @@ impl<T: 'static + StdError> From<RusotoError<T>> for UploadError {
     }
 }
 
+/// try_read_exact tries to read exact length data as the buffer size.  
+/// like [`std::io::Read::read_exact`], but won't return `UnexpectedEof` when cannot read anything more from the `Read`.  
+/// once returning a size less than the buffer length, implies a EOF was meet, or nothing readed.
+///
+/// # Examples
+/// ```rust
+
+/// ```
+async fn try_read_exact<R: AsyncRead + ?Sized + Unpin>(
+    r: &mut R,
+    buf: &mut [u8],
+) -> io::Result<usize> {
+    let mut size_readed = 0;
+    loop {
+        let r = r.read(&mut buf[size_readed..]).await?;
+        if r == 0 {
+            return Ok(size_readed);
+        }
+        size_readed += r;
+        if size_readed >= buf.len() {
+            return Ok(size_readed);
+        }
+    }
+}
+
 /// Specifies the minimum size to use multi-part upload.
 /// AWS S3 requires each part to be at least 5 MiB.
 const MINIMUM_PART_SIZE: usize = 5 * 1024 * 1024;
@@ -302,7 +327,7 @@ impl<'client> S3Uploader<'client> {
                 let mut buf = vec![0; self.multi_part_size];
                 let mut part_number = 1;
                 loop {
-                    let data_size = reader.read(&mut buf).await?;
+                    let data_size = try_read_exact(reader, &mut buf).await?;
                     if data_size == 0 {
                         break;
                     }
@@ -564,6 +589,8 @@ impl BlobStorage for S3Storage {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
+
     use super::*;
     use rusoto_core::signature::SignedRequest;
     use rusoto_mock::{MockRequestDispatcher, MultipleMockRequestDispatcher};
@@ -875,5 +902,28 @@ mod tests {
         cd.set_attrs(attrs);
         cd.set_bucket(bucket);
         cd
+    }
+
+    #[tokio::test]
+    async fn test_try_read_exact() {
+        use self::try_read_exact;
+        use futures::io::AllowStdIo;
+        use std::io::{self, Cursor, Read};
+
+        /// ThrottleRead throttles a `Read` -- make it emits one char for each `read` call.
+        struct ThrottleRead<R>(R);
+        impl<R: Read> Read for ThrottleRead<R> {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                self.0.read(&mut buf[..1])
+            }
+        }
+
+        let mut data = AllowStdIo::new(ThrottleRead(Cursor::new(b"muthologia")));
+        let mut buf = vec![0u8; 6];
+        assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(6));
+        assert_eq!(buf, b"muthol");
+        assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(4));
+        assert_eq!(&buf[..4], b"ogia");
+        assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(0));
     }
 }

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -265,11 +265,6 @@ impl<T: 'static + StdError> From<RusotoError<T>> for UploadError {
 /// try_read_exact tries to read exact length data as the buffer size.  
 /// like [`std::io::Read::read_exact`], but won't return `UnexpectedEof` when cannot read anything more from the `Read`.  
 /// once returning a size less than the buffer length, implies a EOF was meet, or nothing readed.
-///
-/// # Examples
-/// ```rust
-
-/// ```
 async fn try_read_exact<R: AsyncRead + ?Sized + Unpin>(
     r: &mut R,
     buf: &mut [u8],


### PR DESCRIPTION
This PR fixed a bug that caused the S3 storage sometime failed to upload when the `Read` is a file in the disk.
For details see https://github.com/tikv/tikv/issues/12325.