### PR TITLE
set uuid for header to prevent raftstore merging

### DIFF
--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -878,6 +878,11 @@ fn make_request_header(mut context: Context) -> RaftRequestHeader {
     let mut header = RaftRequestHeader::default();
     header.set_peer(context.take_peer());
     header.set_region_id(region_id);
+    // Set the UUID of header to prevent raftstore batching our requests.
+    // The current `resolved_ts` observer assumes that each batch of request doesn't has
+    // two writes to the same key. (Even with 2 different TS). That was true for normal cases
+    // because the latches reject concurrency write to keys. However we have bypassed the latch layer :(
+    header.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
     header.set_region_epoch(context.take_region_epoch());
     header
 }

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -878,18 +878,18 @@ fn make_request_header(mut context: Context) -> RaftRequestHeader {
     let mut header = RaftRequestHeader::default();
     header.set_peer(context.take_peer());
     header.set_region_id(region_id);
-    // Set the UUID of header to prevent raftstore batching our requests.
-    // The current `resolved_ts` observer assumes that each batch of request doesn't has
-    // two writes to the same key. (Even with 2 different TS). That was true for normal cases
-    // because the latches reject concurrency write to keys. However we have bypassed the latch layer :(
-    header.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
     header.set_region_epoch(context.take_region_epoch());
     header
 }
 
 fn make_request(reqs: &mut HashMap<Vec<u8>, Request>, context: Context) -> RaftCmdRequest {
     let mut cmd = RaftCmdRequest::default();
-    let header = make_request_header(context);
+    let mut header = make_request_header(context);
+    // Set the UUID of header to prevent raftstore batching our requests.
+    // The current `resolved_ts` observer assumes that each batch of request doesn't has
+    // two writes to the same key. (Even with 2 different TS). That was true for normal cases
+    // because the latches reject concurrency write to keys. However we have bypassed the latch layer :(
+    header.set_uuid(uuid::Uuid::new_v4().as_bytes().to_vec());
     cmd.set_header(header);
     cmd.set_requests(
         std::mem::take(reqs)


### PR DESCRIPTION
This PR fixed a bug that caused TiKV panic during log restoring because of the duplicated key in the same `RaftCmdRequest`.

We did make keys distinct when building requests, but the raftstore may merge small requests(see `BatchRaftCmdRequestBuilder`). This PR set the UUID field in the header so it won't try to merge two distinct requests.