### PR TITLE
backup-stream: fix some bugs in log backup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=br-stream#2f16e3348000384674e40ab7f2e6f4ea2577887e"
+source = "git+https://github.com/pingcap/kvproto.git?branch=br-stream#762b02ddcc44a3bd4d407a69e623877795c8fe2f"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,6 +5041,7 @@ version = "0.1.0"
 dependencies = [
  "api_version",
  "crc32fast",
+ "dashmap",
  "encryption",
  "engine_rocks",
  "engine_traits",

--- a/components/backup-stream/src/metadata/client.rs
+++ b/components/backup-stream/src/metadata/client.rs
@@ -205,7 +205,7 @@ impl<Store: MetaStore> MetadataClient<Store> {
                 task_name: name.to_owned(),
             });
         }
-        let info = protobuf::parse_from_bytes::<StreamBackupTaskInfo>(&items[0].value())?;
+        let info = protobuf::parse_from_bytes::<StreamBackupTaskInfo>(items[0].value())?;
         let is_paused = self.check_task_paused(name).await?;
 
         Ok(StreamTask { info, is_paused })
@@ -224,7 +224,7 @@ impl<Store: MetaStore> MetadataClient<Store> {
         let mut tasks = Vec::with_capacity(kvs.len());
         for kv in kvs {
             tasks.push(StreamTask {
-                info: protobuf::parse_from_bytes(&kv.value())?,
+                info: protobuf::parse_from_bytes(kv.value())?,
                 is_paused: pause_hash.contains_key(kv.key()),
             });
         }

--- a/components/backup-stream/src/metadata/client.rs
+++ b/components/backup-stream/src/metadata/client.rs
@@ -151,7 +151,7 @@ impl<Store: MetaStore> MetadataClient<Store> {
 
         let s = self.meta_store.snapshot().await?;
         let r = s.get(Keys::Key(key)).await?;
-        if r.len() < 1 {
+        if r.is_empty() {
             return Ok(None);
         }
         let r = &r[0];
@@ -168,10 +168,9 @@ impl<Store: MetaStore> MetadataClient<Store> {
 
     /// pause a task.
     pub async fn pause(&self, name: &str) -> Result<()> {
-        Ok(self
-            .meta_store
+        self.meta_store
             .set(KeyValue(MetaKey::pause_of(name), vec![]))
-            .await?)
+            .await
     }
 
     pub async fn get_tasks_pause_status(&self) -> Result<HashMap<Vec<u8>, bool>> {

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -768,8 +768,9 @@ impl StreamTaskInfo {
     /// move need-flushing files to flushing_files.
     pub async fn move_to_flushing_files(&self) -> &Self {
         let mut w = self.files.write().await;
+        let mut fw = self.flushing_files.write().await;
         for (k, v) in w.drain() {
-            self.flushing_files.write().await.push((k, v));
+            fw.push((k, v));
         }
         self
     }

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -543,7 +543,7 @@ mod test {
             .unwrap();
         info!("err"; "err" => ?err);
         assert_eq!(err.error_code, error_code::backup_stream::OTHER.code);
-        assert!(err.error_message.find("everything is alright").is_some());
+        assert!(err.error_message.contains("everything is alright"));
         assert_eq!(err.store_id, *victim);
         let paused = run_async_test(meta_cli.check_task_paused("test_fatal_error")).unwrap();
         assert!(paused)

--- a/components/sst_importer/Cargo.toml
+++ b/components/sst_importer/Cargo.toml
@@ -29,6 +29,7 @@ kvproto = { git = "https://github.com/pingcap/kvproto.git", branch="br-stream" }
 lazy_static = "1.3"
 log_wrappers = { path = "../log_wrappers" }
 prometheus = { version = "0.13", default-features = false }
+dashmap = "5"
 serde = "1.0"
 serde_derive = "1.0"
 slog = { version = "2.3", features = ["max_level_trace", "release_max_level_debug"] }

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -221,6 +221,10 @@ impl ImportDir {
         })
     }
 
+    pub fn get_root_dir(&self) -> &PathBuf {
+        &self.root_dir
+    }
+
     pub fn get_import_path(&self, file_name: &str) -> Result<ImportPath> {
         let save_path = self.root_dir.join(&file_name);
         let temp_path = self.temp_dir.join(&file_name);

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -110,6 +110,15 @@ impl SSTImporter {
         }
     }
 
+    pub fn remove_dir(&self, prefix: &str) -> Result<()> {
+        let path = self.dir.get_root_dir().join(prefix);
+        if path.exists() {
+            file_system::remove_dir_all(&path)?;
+            info!("directory {:?} has been removed", path);
+        }
+        Ok(())
+    }
+
     pub fn validate(&self, meta: &SstMeta) -> Result<SSTMetaInfo> {
         self.dir.validate(meta, self.key_manager.clone())
     }
@@ -277,15 +286,17 @@ impl SSTImporter {
         let path = self.dir.get_import_path(name)?;
         let start = Instant::now();
         let sha256 = meta.get_sha256().to_vec();
-        let expected_sha256 = if sha256.len() > 0 { Some(sha256) } else { None };
+        let expected_sha256 = if !sha256.is_empty() { Some(sha256) } else { None };
         if path.save.exists() {
             return Ok(path.save);
         }
-        let l = self
+
+        let entry = self
             .file_locks
             .entry(name.to_string())
             .or_insert(Mutex::new(()));
-        let _ = l.lock();
+
+        let lock = entry.lock();
         if path.save.exists() {
             return Ok(path.save);
         }
@@ -303,7 +314,8 @@ impl SSTImporter {
         info!("download file finished {}", name);
 
         std::fs::rename(path.temp, path.save.clone())?;
-        self.file_locks.remove(name.clone());
+        drop(lock);
+        self.file_locks.remove(name);
 
         IMPORTER_APPLY_DURATION
             .with_label_values(&["download"])
@@ -1088,7 +1100,7 @@ mod tests {
         let input_len = input.len() as u64;
 
         let mut hasher = Hasher::new(MessageDigest::sha256()).unwrap();
-        hasher.update(data);
+        hasher.update(data).unwrap();
         let hash256 = hasher.finish().unwrap().to_vec();
 
         block_on_external_io(external_storage_export::read_external_storage_into_file(

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -1,12 +1,13 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
+use dashmap::DashMap;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use futures::executor::ThreadPool;
 use kvproto::brpb::{CipherInfo, StorageBackend};
@@ -41,6 +42,7 @@ pub struct SSTImporter {
     switcher: ImportModeSwitcher,
     api_version: ApiVersion,
     compression_types: HashMap<CfName, SstCompressionType>,
+    file_locks: DashMap<String, Mutex<()>>,
 }
 
 impl SSTImporter {
@@ -57,6 +59,7 @@ impl SSTImporter {
             switcher,
             api_version,
             compression_types: HashMap::with_capacity(2),
+            file_locks: DashMap::default(),
         })
     }
 
@@ -275,7 +278,17 @@ impl SSTImporter {
         let start = Instant::now();
         let sha256 = meta.get_sha256().to_vec();
         let expected_sha256 = if sha256.len() > 0 { Some(sha256) } else { None };
-
+        if path.save.exists() {
+            return Ok(path.save);
+        }
+        let l = self
+            .file_locks
+            .entry(name.to_string())
+            .or_insert(Mutex::new(()));
+        let _ = l.lock();
+        if path.save.exists() {
+            return Ok(path.save);
+        }
         self.download_file_from_external_storage(
             // don't check file length after download file for now.
             meta.get_length(),
@@ -289,11 +302,14 @@ impl SSTImporter {
         )?;
         info!("download file finished {}", name);
 
+        std::fs::rename(path.temp, path.save.clone())?;
+        self.file_locks.remove(name.clone());
+
         IMPORTER_APPLY_DURATION
             .with_label_values(&["download"])
             .observe(start.saturating_elapsed().as_secs_f64());
 
-        Ok(path.temp)
+        Ok(path.save)
     }
 
     pub fn do_apply_kv_file<P: AsRef<Path>>(

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -377,7 +377,7 @@ impl SSTImporter {
                 // so if we met the key not satisfy the ts.
                 // we can easily filter the remain keys.
                 ts_not_expected += 1;
-                break;
+                continue;
             }
             if perform_rewrite {
                 let old_key = event_iter.key();

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -42,7 +42,7 @@ pub struct SSTImporter {
     switcher: ImportModeSwitcher,
     api_version: ApiVersion,
     compression_types: HashMap<CfName, SstCompressionType>,
-    file_locks: DashMap<String, Mutex<()>>,
+    file_locks: Arc<DashMap<String, Mutex<()>>>,
 }
 
 impl SSTImporter {
@@ -59,7 +59,7 @@ impl SSTImporter {
             switcher,
             api_version,
             compression_types: HashMap::with_capacity(2),
-            file_locks: DashMap::default(),
+            file_locks: Arc::new(DashMap::default()),
         })
     }
 
@@ -286,20 +286,25 @@ impl SSTImporter {
         let path = self.dir.get_import_path(name)?;
         let start = Instant::now();
         let sha256 = meta.get_sha256().to_vec();
-        let expected_sha256 = if !sha256.is_empty() { Some(sha256) } else { None };
+        let expected_sha256 = if !sha256.is_empty() {
+            Some(sha256)
+        } else {
+            None
+        };
         if path.save.exists() {
             return Ok(path.save);
         }
 
-        let entry = self
+        let lock = self
             .file_locks
             .entry(name.to_string())
             .or_insert(Mutex::new(()));
+        let guard = lock.value().lock().unwrap();
 
-        let lock = entry.lock();
         if path.save.exists() {
             return Ok(path.save);
         }
+
         self.download_file_from_external_storage(
             // don't check file length after download file for now.
             meta.get_length(),
@@ -313,7 +318,13 @@ impl SSTImporter {
         )?;
         info!("download file finished {}", name);
 
-        std::fs::rename(path.temp, path.save.clone())?;
+        if let Some(p) = path.save.parent() {
+            // we have v1 prefix in file name.
+            file_system::create_dir_all(p)?;
+        }
+        file_system::rename(path.temp, path.save.clone())?;
+
+        drop(guard);
         drop(lock);
         self.file_locks.remove(name);
 
@@ -334,7 +345,7 @@ impl SSTImporter {
         build_fn: &mut dyn FnMut(Vec<u8>, Vec<u8>),
     ) -> Result<Option<Range>> {
         // iterator file and performs rewrites and apply.
-        let file = File::open(file_path)?;
+        let file = File::open(&file_path)?;
         let mut reader = BufReader::new(file);
         let mut buffer = Vec::new();
         reader.read_to_end(&mut buffer)?;
@@ -352,18 +363,25 @@ impl SSTImporter {
         let mut smallest_key = None;
         let mut largest_key = None;
 
+        let mut total_key = 0;
+        let mut ts_not_expected = 0;
+        let mut not_in_range = 0;
+
         let start = Instant::now();
         loop {
             if !event_iter.valid() {
                 break;
             }
+            total_key += 1;
             event_iter.next()?;
 
+            INPORTER_APPLY_COUNT.with_label_values(&["key_meet"]).inc();
             let ts = Key::decode_ts_from(event_iter.key())?;
             if ts > TimeStamp::new(restore_ts) {
                 // we assume the keys in file are sorted by ts.
                 // so if we met the key not satisfy the ts.
                 // we can easily filter the remain keys.
+                ts_not_expected += 1;
                 break;
             }
             if perform_rewrite {
@@ -394,6 +412,7 @@ impl SSTImporter {
                 INPORTER_APPLY_COUNT
                     .with_label_values(&["key_not_in_region"])
                     .inc();
+                not_in_range += 1;
                 continue;
             }
             let value = event_iter.value().to_vec();
@@ -410,6 +429,10 @@ impl SSTImporter {
                 |v: Vec<u8>| Some(v.max(iter_key.clone())),
             );
         }
+        info!("build download request file done"; "total keys" => %total_key,
+            "ts filtered keys" => %ts_not_expected,
+            "range filtered keys" => %not_in_range,
+            "file" => %file_path.as_ref().display());
 
         let label = if perform_rewrite { "rewrite" } else { "normal" };
         IMPORTER_APPLY_DURATION

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::{prelude::*, BufReader};
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use futures::executor::ThreadPool;
 use kvproto::brpb::{CipherInfo, StorageBackend};
@@ -42,7 +42,7 @@ pub struct SSTImporter {
     switcher: ImportModeSwitcher,
     api_version: ApiVersion,
     compression_types: HashMap<CfName, SstCompressionType>,
-    file_locks: Arc<DashMap<String, Mutex<()>>>,
+    file_locks: Arc<DashMap<String, ()>>,
 }
 
 impl SSTImporter {
@@ -295,11 +295,7 @@ impl SSTImporter {
             return Ok(path.save);
         }
 
-        let lock = self
-            .file_locks
-            .entry(name.to_string())
-            .or_insert(Mutex::new(()));
-        let guard = lock.value().lock().unwrap();
+        let lock = self.file_locks.entry(name.to_string()).or_default();
 
         if path.save.exists() {
             return Ok(path.save);
@@ -324,7 +320,6 @@ impl SSTImporter {
         }
         file_system::rename(path.temp, path.save.clone())?;
 
-        drop(guard);
         drop(lock);
         self.file_locks.remove(name);
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -168,7 +168,7 @@ where
     // will panic if found duplicated entry during Vec<PutRequest>.
     fn build_apply_request<'a, 'b>(
         raft_size: u64,
-        reqs: &'a mut HashMap<Vec<u8>, Request>,
+        reqs: &'a mut HashMap<Vec<u8>, (Request, u64)>,
         cmd_reqs: &'a mut Vec<RaftCmdRequest>,
         is_delete: bool,
         cf: &'b str,
@@ -185,13 +185,19 @@ where
                 let mut req = Request::default();
                 let mut del = DeleteRequest::default();
 
-                let hk = Key::truncate_ts_for(&k).expect("key without ts").to_vec();
-                del.set_key(k);
+                let (encoded_key, ts) = Key::split_on_ts_for(&k).expect("key without ts");
+                del.set_key(k.clone());
                 del.set_cf(cf.to_string());
                 req.set_cmd_type(CmdType::Delete);
                 req.set_delete(del);
                 req_size += req.compute_size() as u64;
-                reqs.insert(hk, req);
+                if reqs
+                    .get(encoded_key)
+                    .map(|(_, old_ts)| *old_ts < ts.into_inner())
+                    .unwrap_or(true)
+                {
+                    reqs.insert(encoded_key.to_owned(), (req, ts.into_inner()));
+                };
                 if req_size > raft_size / 2 {
                     req_size = 0;
                     let cmd = make_request(reqs, context.clone());
@@ -202,14 +208,21 @@ where
             Box::new(move |k: Vec<u8>, v: Vec<u8>| {
                 let mut req = Request::default();
                 let mut put = PutRequest::default();
-                let hk = Key::truncate_ts_for(&k).expect("key without ts").to_vec();
-                put.set_key(k);
+
+                let (encoded_key, ts) = Key::split_on_ts_for(&k).expect("key without ts");
+                put.set_key(k.clone());
                 put.set_value(v);
                 put.set_cf(cf.to_string());
                 req.set_cmd_type(CmdType::Put);
                 req.set_put(put);
                 req_size += req.compute_size() as u64;
-                reqs.insert(hk, req);
+                if reqs
+                    .get(encoded_key)
+                    .map(|(_, old_ts)| *old_ts < ts.into_inner())
+                    .unwrap_or(true)
+                {
+                    reqs.insert(encoded_key.to_owned(), (req, ts.into_inner()));
+                };
                 if req_size > raft_size / 2 {
                     req_size = 0;
                     let cmd = make_request(reqs, context.clone());
@@ -503,7 +516,7 @@ where
             let result = (|| -> Result<()> {
                 let temp_file =
                     importer.do_download_kv_file(meta, req.get_storage_backend(), &limiter)?;
-                let mut reqs = HashMap::<Vec<u8>, Request>::default();
+                let mut reqs = HashMap::<Vec<u8>, (Request, u64)>::default();
                 let mut cmd_reqs = vec![];
                 let mut build_req_fn = Self::build_apply_request(
                     raft_size.0,
@@ -917,7 +930,7 @@ fn make_request_header(mut context: Context) -> RaftRequestHeader {
     header
 }
 
-fn make_request(reqs: &mut HashMap<Vec<u8>, Request>, context: Context) -> RaftCmdRequest {
+fn make_request(reqs: &mut HashMap<Vec<u8>, (Request, u64)>, context: Context) -> RaftCmdRequest {
     let mut cmd = RaftCmdRequest::default();
     let mut header = make_request_header(context);
     // Set the UUID of header to prevent raftstore batching our requests.
@@ -929,6 +942,7 @@ fn make_request(reqs: &mut HashMap<Vec<u8>, Request>, context: Context) -> RaftC
     cmd.set_requests(
         std::mem::take(reqs)
             .into_values()
+            .map(|(req, _)| req)
             .collect::<Vec<Request>>()
             .into(),
     );

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -439,6 +439,41 @@ where
         self.threads.spawn_ok(handle_task);
     }
 
+    // clear_files the KV files after apply finished.
+    // it will remove the direcotry in import path.
+    fn clear_files(
+        &mut self,
+        _ctx: RpcContext<'_>,
+        req: ClearRequest,
+        sink: UnarySink<ClearResponse>,
+    ) {
+        let label = "clear_files";
+        let timer = Instant::now_coarse();
+        let importer = Arc::clone(&self.importer);
+        let start = Instant::now();
+        let mut resp = ClearResponse::default();
+
+        let handle_task = async move {
+            // Records how long the apply task waits to be scheduled.
+            sst_importer::metrics::IMPORTER_APPLY_DURATION
+                .with_label_values(&["queue"])
+                .observe(start.saturating_elapsed().as_secs_f64());
+
+            if let Err(e) = importer.remove_dir(req.get_prefix()) {
+                let mut import_err = kvproto::import_sstpb::Error::default();
+                import_err.set_message(format!("failed to remove directory: {}", e));
+                resp.set_error(import_err);
+            }
+            sst_importer::metrics::IMPORTER_APPLY_DURATION
+                .with_label_values(&[label])
+                .observe(start.saturating_elapsed().as_secs_f64());
+
+            let resp = Ok(resp);
+            crate::send_rpc_response!(resp, sink, label, timer);
+        };
+        self.threads.spawn_ok(handle_task);
+    }
+
     // Downloads KV file and performs key-rewrite then apply kv into this tikv store.
     fn apply(
         &mut self,


### PR DESCRIPTION
Signed-off-by: 3pointer <luancheng@pingcap.com>

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/pingcap/tidb/issues/34098

What's Changed:
1. implement clear rpc for sst_services.
2. fix the bug that repeated download kv file in apply.
3. run make clippy.
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->


### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
with https://github.com/pingcap/tidb/pull/34103/files, I checked the `v1` directory has been removed. and in tikv.log we can see
[2022/04/20 16:04:58.121 +08:00] [INFO] [sst_importer.rs:117] ["directory \"/home/cluster/restore/tidb-data-restore/tikv-20260/import/v1\" has been removed"]

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note.
If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
```
