### PR TITLE
Added retry for initial scanning and some metrics

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -802,7 +802,9 @@ where
                     region.get_id()
                 )
             })?;
-        let new_region_info = rx.recv().expect("BUG: unexpected channel closed");
+        let new_region_info = rx
+            .recv()
+            .map_err(|err| annotate!(err, "BUG?: unexpected channel message dropped."))?;
         if new_region_info.is_none() {
             metrics::SKIP_RETRY
                 .with_label_values(&["region-absent"])

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -15,6 +15,7 @@ use error_code::ErrorCodeExt;
 use kvproto::brpb::StreamBackupError;
 use kvproto::metapb::Region;
 use pd_client::PdClient;
+use raft::StateRole;
 use raftstore::router::RaftStoreRouter;
 use raftstore::store::fsm::ChangeObserver;
 
@@ -26,6 +27,7 @@ use tokio::runtime::Runtime;
 use tokio_stream::StreamExt;
 use txn_types::TimeStamp;
 
+use crate::annotate;
 use crate::errors::Error;
 use crate::event_loader::InitialDataLoader;
 use crate::metadata::store::{EtcdStore, MetaStore};
@@ -41,7 +43,7 @@ use raftstore::coprocessor::{CmdBatch, ObserveHandle, RegionInfoProvider};
 use tikv::config::BackupStreamConfig;
 
 use tikv_util::worker::{Runnable, Scheduler};
-use tikv_util::{debug, error, info};
+use tikv_util::{box_err, debug, error, info};
 use tikv_util::{warn, HandyRwLock};
 
 use super::metrics::{HANDLE_EVENT_DURATION_HISTOGRAM, HANDLE_KV_HISTOGRAM};
@@ -149,6 +151,7 @@ where
         pd_client: Arc<PDC>,
         concurrency_manager: ConcurrencyManager,
     ) -> Endpoint<EtcdStore, R, E, RT, PDC> {
+        crate::metrics::STREAM_ENABLED.inc();
         let pool = create_tokio_runtime(config.num_threads, "backup-stream")
             .expect("failed to create tokio runtime for backup stream worker.");
 
@@ -393,6 +396,7 @@ where
             self.regions.clone(),
             self.range_router.clone(),
             self.subs.clone(),
+            self.scheduler.clone(),
         )
     }
 
@@ -421,12 +425,6 @@ where
         end_key: Vec<u8>,
     ) -> Result<()> {
         let start = Instant::now_coarse();
-        let mut start_ts = task.info.get_start_ts();
-        // Should scan from checkpoint_ts rather than start_ts if checkpoint_ts exists in Metadata.
-        if let Some(cli) = &self.meta_client {
-            let checkpoint_ts = cli.progress_of_task(task.info.get_name()).await?;
-            start_ts = start_ts.max(checkpoint_ts);
-        }
         let success = self
             .observer
             .ranges
@@ -440,17 +438,16 @@ where
             );
         }
         tokio::task::spawn_blocking(move || {
-            let range_init_result =
-                init.initialize_range(start_key.clone(), end_key.clone(), TimeStamp::new(start_ts));
+            let range_init_result = init.initialize_range(start_key.clone(), end_key.clone());
             match range_init_result {
-                Ok(stat) => {
-                    info!("backup stream success to do initial scanning"; "stat" => ?stat,
+                Ok(()) => {
+                    info!("backup stream success to initialize"; 
                         "start_key" => utils::redact(&start_key),
                         "end_key" => utils::redact(&end_key),
                         "take" => ?start.saturating_elapsed(),)
                 }
                 Err(e) => {
-                    e.report("backup stream do initial scanning failed");
+                    e.report("backup stream initialize failed");
                 }
             }
         });
@@ -632,9 +629,8 @@ where
 
     /// Start observe over some region.
     /// This would modify some internal state, and delegate the task to InitialLoader::observe_over.
-    fn observe_over(&self, region: &Region) -> Result<()> {
+    fn observe_over(&self, region: &Region, handle: ObserveHandle) -> Result<()> {
         let init = self.make_initial_loader();
-        let handle = ObserveHandle::new();
         let region_id = region.get_id();
         self.subs.register_region(&region, handle.clone(), None);
         init.observe_over_with_retry(region, || {
@@ -647,10 +643,10 @@ where
         &self,
         region: &Region,
         task: String,
+        handle: ObserveHandle,
     ) -> Result<()> {
         let init = self.make_initial_loader();
 
-        let handle = ObserveHandle::new();
         let meta_cli = self.meta_client.as_ref().unwrap().clone();
         let last_checkpoint = TimeStamp::new(
             self.pool
@@ -665,15 +661,13 @@ where
         })?;
         let region = region.clone();
 
-        // Note: Even we did the initial scanning, if the next_backup_ts was updated by periodic flushing,
-        //       before the initial scanning done, there is still possibility of losing data:
-        //       if the server crashes immediately, and data of this scanning hasn't been sent to sink,
-        //       those data would be permanently lost.
-        // Maybe we need block the next_backup_ts from advancing before all initial scanning done(Or just for the region, via disabling the resolver)?
         self.pool.spawn_blocking(move || {
             match init.do_initial_scan(&region, last_checkpoint, snap) {
                 Ok(stat) => {
                     info!("initial scanning of leader transforming finished!"; "statistics" => ?stat, "region" => %region.get_id(), "from_ts" => %last_checkpoint);
+                    utils::record_cf_stat("lock", &stat.lock);
+                    utils::record_cf_stat("write", &stat.write);
+                    utils::record_cf_stat("default", &stat.data);
                 }
                 Err(err) => err.report(format!("during initial scanning of region {:?}", region)),
             }
@@ -694,32 +688,14 @@ where
             ObserveOp::Start {
                 region,
                 needs_initial_scanning,
-            } => {
-                let result = if needs_initial_scanning {
-                    let for_task = self.find_task_by_region(&region).unwrap_or_else(|| {
-                        panic!(
-                            "BUG: the region {:?} is register to no task but being observed",
-                            region
-                        )
-                    });
-                    self.observe_over_with_initial_data_from_checkpoint(&region, for_task)
-                } else {
-                    self.observe_over(&region)
-                };
-                if let Err(err) = result {
-                    err.report(format!(
-                        "during doing initial scanning for region {:?}",
-                        region
-                    ));
-                }
-            }
+            } => self.start_observe(region, needs_initial_scanning),
             ObserveOp::Stop { ref region } => {
                 self.subs.deregister_region(region, |_, _| true);
             }
             ObserveOp::CheckEpochAndStop { ref region } => {
                 self.subs.deregister_region(region, |old, new| {
                     raftstore::store::util::compare_region_epoch(
-                        old.get_region_epoch(),
+                        old.meta.get_region_epoch(),
                         new,
                         true,
                         true,
@@ -734,6 +710,7 @@ where
 
                 if need_refresh_all {
                     let canceled = self.subs.deregister_region(region, |_, _| true);
+                    let handle = ObserveHandle::new();
                     if canceled {
                         let for_task = self.find_task_by_region(&region).unwrap_or_else(|| {
                             panic!(
@@ -741,18 +718,114 @@ where
                                 region
                             )
                         });
-                        if let Err(e) =
-                            self.observe_over_with_initial_data_from_checkpoint(&region, for_task)
-                        {
-                            e.report(format!(
-                                "register region {} to raftstore when refreshing",
-                                region.get_id()
-                            ));
+                        if let Err(e) = self.observe_over_with_initial_data_from_checkpoint(
+                            &region,
+                            for_task,
+                            handle.clone(),
+                        ) {
+                            try_send!(
+                                self.scheduler,
+                                Task::ModifyObserve(ObserveOp::NotifyFailToStartObserve {
+                                    region: region.clone(),
+                                    handle,
+                                    err: Box::new(e)
+                                })
+                            );
                         }
                     }
                 }
             }
+            ObserveOp::NotifyFailToStartObserve {
+                region,
+                handle,
+                err,
+            } => {
+                info!("retry observe region"; "region" => %region.get_id(), "err" => %err);
+                match self.retry_observe(region, handle) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        try_send!(
+                            self.scheduler,
+                            Task::FatalError(
+                                format!("While retring to observe region, origin error is {}", err),
+                                Box::new(e)
+                            )
+                        );
+                    }
+                }
+            }
         }
+    }
+
+    fn start_observe(&self, region: Region, needs_initial_scanning: bool) {
+        let handle = ObserveHandle::new();
+        let result = if needs_initial_scanning {
+            let for_task = self.find_task_by_region(&region).unwrap_or_else(|| {
+                panic!(
+                    "BUG: the region {:?} is register to no task but being observed (start_key = {}; end_key = {}; task_stat = {:?})",
+                    region, utils::redact(&region.get_start_key()), utils::redact(&region.get_end_key()), self.range_router
+                )
+            });
+            self.observe_over_with_initial_data_from_checkpoint(&region, for_task, handle.clone())
+        } else {
+            self.observe_over(&region, handle.clone())
+        };
+        if let Err(err) = result {
+            try_send!(
+                self.scheduler,
+                Task::ModifyObserve(ObserveOp::NotifyFailToStartObserve {
+                    region,
+                    handle,
+                    err: Box::new(err)
+                })
+            );
+        }
+    }
+
+    fn retry_observe(&self, region: Region, handle: ObserveHandle) -> Result<()> {
+        let (tx, rx) = crossbeam::channel::bounded(1);
+        self.regions
+            .find_region_by_id(
+                region.get_id(),
+                Box::new(move |item| {
+                    tx.send(item)
+                        .expect("BUG: failed to send to newly created channel.");
+                }),
+            )
+            .map_err(|err| {
+                annotate!(
+                    err,
+                    "failed to send request to region info accessor, server maybe too too too busy. (region id = {})",
+                    region.get_id()
+                )
+            })?;
+        let new_region_info = rx.recv().expect("BUG: unexpected channel closed");
+        if new_region_info.is_none() {
+            metrics::SKIP_RETRY
+                .with_label_values(&["region-absent"])
+                .inc();
+            return Ok(());
+        }
+        if new_region_info
+            .as_ref()
+            .map(|r| r.role != StateRole::Leader)
+            .unwrap_or(true)
+        {
+            metrics::SKIP_RETRY.with_label_values(&["not-leader"]).inc();
+            return Ok(());
+        }
+        if !self.subs.deregister_region(&region, |old, _| {
+            let should_remove = old.handle().id == handle.id;
+            if !should_remove {
+                warn!("stale retry command"; "region" => ?region, "handle" => ?handle, "old_handle" => ?old.handle());
+            }
+            should_remove
+        }) {
+            metrics::SKIP_RETRY.with_label_values(&["stale-command"]).inc();
+            return Ok(());
+        }
+        self.start_observe(region, true);
+        Ok(())
     }
 
     pub fn run_task(&self, task: Task) {
@@ -834,6 +907,11 @@ pub enum ObserveOp {
     },
     RefreshResolver {
         region: Region,
+    },
+    NotifyFailToStartObserve {
+        region: Region,
+        handle: ObserveHandle,
+        err: Box<Error>,
     },
 }
 

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -370,14 +370,12 @@ where
             let kv_count = kvs.len();
             let total_size = kvs.size();
             metrics::HEAP_MEMORY
-                .with_label_values(&["alloc"])
-                .inc_by(total_size as f64);
+                .add(total_size as _);
             if let Err(err) = router.on_events(kvs).await {
                 err.report("failed to send event.");
             }
             metrics::HEAP_MEMORY
-                .with_label_values(&["free"])
-                .inc_by(total_size as f64);
+                .sub(total_size as _);
             HANDLE_KV_HISTOGRAM.observe(kv_count as _);
             let time_cost = sw.lap().as_secs_f64();
             if time_cost > SLOW_EVENT_THRESHOLD {

--- a/components/backup-stream/src/errors.rs
+++ b/components/backup-stream/src/errors.rs
@@ -142,6 +142,14 @@ impl Error {
         }
     }
 
+    /// add some context to the error.
+    pub fn context(self, msg: impl Display) -> Self {
+        Self::Contextual {
+            inner_error: Box::new(self),
+            context: msg.to_string(),
+        }
+    }
+
     fn kind(&self) -> &'static str {
         self.error_code().code
     }

--- a/components/backup-stream/src/event_loader.rs
+++ b/components/backup-stream/src/event_loader.rs
@@ -296,12 +296,11 @@ where
             stats.add_statistics(&stat);
             let sink = self.sink.clone();
             let event_size = events.size();
+            let sched = self.scheduler.clone();
             metrics::INCREMENTAL_SCAN_SIZE.observe(event_size as f64);
             metrics::HEAP_MEMORY.add(event_size as _);
             join_handles.push(tokio::spawn(async move {
-                if let Err(err) = sink.on_events(events).await {
-                    warn!("failed to send event to sink"; "err" => %err);
-                }
+                utils::handle_on_event_result(&sched, sink.on_events(events).await);
                 metrics::HEAP_MEMORY.sub(event_size as _);
             }));
         }

--- a/components/backup-stream/src/event_loader.rs
+++ b/components/backup-stream/src/event_loader.rs
@@ -328,7 +328,10 @@ where
                     warn!("failed to join task."; "err" => %err);
                 }
             }
-            if let Err(err) = Self::with_resolver_by(&tr, region_id, |r| Ok(r.phase_one_done())) {
+            if let Err(err) = Self::with_resolver_by(&tr, region_id, |r| {
+                r.phase_one_done();
+                Ok(())
+            }) {
                 err.report(format_args!(
                     "failed to finish phase 1 for region {:?}",
                     region_id

--- a/components/backup-stream/src/metrics.rs
+++ b/components/backup-stream/src/metrics.rs
@@ -60,10 +60,39 @@ lazy_static! {
         exponential_buckets(1.0, 2.0, 16).unwrap()
     )
     .unwrap();
+    pub static ref FLUSH_FILE_SIZE: Histogram = register_histogram!(
+        "tikv_stream_flush_file_size",
+        "Some statistics of flushing of this run.",
+        exponential_buckets(1024.0, 2.0, 16).unwrap()
+    )
+    .unwrap();
     pub static ref INITIAL_SCAN_DURATION: Histogram = register_histogram!(
-        "tikv_stream_initial_scan_duration",
+        "tikv_stream_initial_scan_duration_sec",
         "The duration of initial scanning.",
         exponential_buckets(0.001, 2.0, 16).unwrap()
+    )
+    .unwrap();
+    pub static ref SKIP_RETRY: IntCounterVec = register_int_counter_vec!(
+        "tikv_stream_skip_retry_observe",
+        "The reason of giving up observing region when meeting error.",
+        &["reason"],
+    )
+    .unwrap();
+    pub static ref INITIAL_SCAN_STAT: IntCounterVec = register_int_counter_vec!(
+        "tikv_stream_initial_scan_operations",
+        "The operations over rocksdb during initial scanning.",
+        &["cf", "op"],
+    )
+    .unwrap();
+    pub static ref STREAM_ENABLED: IntCounter = register_int_counter!(
+        "tikv_stream_enabled",
+        "When gt 0, this node enabled streaming."
+    )
+    .unwrap();
+    pub static ref TRACK_REGION: IntCounterVec = register_int_counter_vec!(
+        "tikv_stream_observed_region",
+        "the region being observed by the current store.",
+        &["type"],
     )
     .unwrap();
 }

--- a/components/backup-stream/src/metrics.rs
+++ b/components/backup-stream/src/metrics.rs
@@ -34,10 +34,9 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
-    pub static ref HEAP_MEMORY: CounterVec = register_counter_vec!(
+    pub static ref HEAP_MEMORY: IntGauge = register_int_gauge!(
         "tikv_stream_heap_memory",
-        "The heap memory allocating by stream backup.",
-        &["type"]
+        "The heap memory allocating by stream backup."
     )
     .unwrap();
     pub static ref ON_EVENT_COST_HISTOGRAM: HistogramVec = register_histogram_vec!(

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -682,10 +682,12 @@ impl StreamTaskInfo {
         let mut w = self.files.write().await;
         // double check before insert. there may be someone already insert that
         // when we are waiting for the write lock.
+        // slience the lint advising us to use the `Entry` API which may introduce copying.
+        #[allow(clippy::map_entry)]
         if !w.contains_key(&key) {
             let path = self.temp_dir.join(key.temp_file_name());
             let val = Mutex::new(DataFile::new(path).await?);
-            w.insert(key.clone(), val);
+            w.insert(key, val);
         }
 
         let f = w.get(&key).unwrap();

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -16,7 +16,7 @@ use std::{
 use crate::{
     annotate,
     endpoint::Task,
-    errors::Error,
+    errors::{ContextualResultExt, Error},
     metadata::StreamTask,
     metrics::SKIP_KV_COUNTER,
     subscription_track::TwoPhaseResolver,
@@ -434,13 +434,13 @@ impl RouterInner {
         Ok(())
     }
 
-    pub async fn on_events(&self, kv: ApplyEvents) -> Result<()> {
+    pub async fn on_events(&self, kv: ApplyEvents) -> Vec<(String, Result<()>)> {
+        use futures::FutureExt;
         let partitioned_events = kv.partition_by_range(&self.ranges.rl());
         let tasks = partitioned_events
             .into_iter()
-            .map(|(task, events)| self.on_event(task, events));
-        futures::future::try_join_all(tasks).await?;
-        Ok(())
+            .map(|(task, events)| self.on_event(task.clone(), events).map(move |r| (task, r)));
+        futures::future::join_all(tasks).await
     }
 
     /// flush the specified task, once once success, return the min resolved ts of this flush.
@@ -497,13 +497,13 @@ impl RouterInner {
 }
 
 /// The handle of a temporary file.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 struct TempFileKey {
-    is_meta: bool,
     table_id: i64,
     region_id: u64,
     cf: CfName,
     cmd_type: CmdType,
+    is_meta: bool,
 }
 
 impl TempFileKey {
@@ -663,7 +663,8 @@ impl StreamTaskInfo {
             flushing_files: RwLock::default(),
             last_flush_time: AtomicPtr::new(Box::into_raw(Box::new(Instant::now()))),
             // TODO make this config set by config or task?
-            flush_interval: Duration::from_secs(FLUSH_STORAGE_INTERVAL),
+            // Keep `0.2 * FLUSH_STORAGE_INTERVAL` for doing flushing.
+            flush_interval: Duration::from_secs((FLUSH_STORAGE_INTERVAL as f64 * 0.8).round() as _),
             total_size: AtomicUsize::new(0),
             flushing: AtomicBool::new(false),
             flush_fail_count: AtomicUsize::new(0),
@@ -696,12 +697,14 @@ impl StreamTaskInfo {
     /// Append a event to the files. This wouldn't trigger `fsync` syscall.
     /// i.e. No guarantee of persistence.
     pub async fn on_events(&self, kv: ApplyEvents) -> Result<()> {
+        use futures::FutureExt;
         let now = Instant::now_coarse();
-        futures::future::try_join_all(
-            kv.partition_by_table_key()
-                .into_iter()
-                .map(|(key, events)| self.on_events_of_key(key, events)),
-        )
+        futures::future::try_join_all(kv.partition_by_table_key().into_iter().map(
+            |(key, events)| {
+                self.on_events_of_key(key, events)
+                    .map(move |r| r.context(format_args!("when handling the file key {:?}", key)))
+            },
+        ))
         .await?;
         crate::metrics::ON_EVENT_COST_HISTOGRAM
             .with_label_values(&["write_to_tempfile"])
@@ -1291,6 +1294,14 @@ mod tests {
             .expect("failed to register task")
     }
 
+    fn check_on_events_result(item: &Vec<(String, Result<()>)>) {
+        for (task, r) in item {
+            if let Err(err) = r {
+                panic!("task {} failed: {}", task, err);
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_basic_file() -> Result<()> {
         test_util::init_log_for_test();
@@ -1312,7 +1323,7 @@ mod tests {
         region1.put_table(CF_WRITE, 1, b"hello", b"still isn't a write record :3");
         region1.delete_table(CF_DEFAULT, 1, b"hello");
         let events = region1.flush_events();
-        router.on_events(events).await?;
+        check_on_events_result(&router.on_events(events).await);
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         let end_ts = TimeStamp::physical_now();
@@ -1461,14 +1472,14 @@ mod tests {
                 i.storage = Arc::new(ErrorStorage::with_first_time_error(i.storage.clone()))
             })
             .await;
-        router.on_events(build_kv_event(0, 10)).await.unwrap();
+        check_on_events_result(&router.on_events(build_kv_event(0, 10)).await);
         assert!(
             router
                 .do_flush("error_prone", 42, TimeStamp::max())
                 .await
                 .is_none()
         );
-        router.on_events(build_kv_event(10, 10)).await.unwrap();
+        check_on_events_result(&router.on_events(build_kv_event(10, 10)).await);
         let _ = router.do_flush("error_prone", 42, TimeStamp::max()).await;
         let t = router.get_task_info("error_prone").await.unwrap();
         assert_eq!(t.total_size(), 0);
@@ -1516,7 +1527,7 @@ mod tests {
             })
             .await;
         for i in 0..=16 {
-            router.on_events(build_kv_event(i * 10, 10)).await.unwrap();
+            check_on_events_result(&router.on_events(build_kv_event(i * 10, 10)).await);
             assert_eq!(
                 router
                     .do_flush("flush_failure", 42, TimeStamp::zero())

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -131,7 +131,7 @@ impl SubscriptionTracer {
         let region_id = region.get_id();
         let remove_result = self
             .0
-            .remove_if(&region_id, |_, old_region| if_cond(&old_region, region));
+            .remove_if(&region_id, |_, old_region| if_cond(old_region, region));
         match remove_result {
             Some(o) => {
                 TRACK_REGION.with_label_values(&["dec"]).inc();
@@ -190,7 +190,10 @@ impl SubscriptionTracer {
         exists && still_observing
     }
 
-    pub fn get_subscription_of(&self, region_id: u64) -> Option<RefMut<u64, RegionSubscription>> {
+    pub fn get_subscription_of(
+        &self,
+        region_id: u64,
+    ) -> Option<RefMut<'_, u64, RegionSubscription>> {
         self.0.get_mut(&region_id)
     }
 }

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -65,7 +65,11 @@ impl RegionSubscription {
 impl SubscriptionTracer {
     /// clear the current `SubscriptionTracer`.
     pub fn clear(&self) {
-        self.0.clear();
+        self.0.retain(|_, v| {
+            v.stop_observing();
+            TRACK_REGION.with_label_values(&["dec"]).inc();
+            false
+        });
     }
 
     // Register a region as tracing.

--- a/components/backup-stream/src/subscription_track.rs
+++ b/components/backup-stream/src/subscription_track.rs
@@ -63,6 +63,11 @@ impl RegionSubscription {
 }
 
 impl SubscriptionTracer {
+    /// clear the current `SubscriptionTracer`.
+    pub fn clear(&self) {
+        self.0.clear();
+    }
+
     // Register a region as tracing.
     // The `start_ts` is used to tracking the progress of initial scanning.
     // (Note: the `None` case of `start_ts` is for testing / refresh region status when split / merge,

--- a/components/backup-stream/tests/mod.rs
+++ b/components/backup-stream/tests/mod.rs
@@ -527,6 +527,7 @@ mod test {
         test_util::init_log_for_test();
         let suite = super::Suite::new("fatal_error", 3);
         suite.must_register_task(1, "test_fatal_error");
+        std::thread::sleep(Duration::from_secs(2));
         let (victim, endpoint) = suite.endpoints.iter().next().unwrap();
         endpoint
             .scheduler()


### PR DESCRIPTION
This PR:
- Added the retry for initial scanning via a message `Task::ModifyObserve(ObserveOp::NotifyFailToStartObserve(...))` for retry initializing a region.
  - This can reduce the error `Error when getting initial snapshot`.
    <img width="348" alt="image" src="https://user-images.githubusercontent.com/36239017/164971329-7b5f5b9a-3cbf-4a52-8d41-3611e31da9ff.png">
  - This can (almost) git rid of data losing because of uninitialized regions.

- Added some metrics.
  - A histogram for recording file size of each flush. This allow us to get statistics about the backup status of current run.
    <img width="1071" alt="image" src="https://user-images.githubusercontent.com/36239017/164971530-89d3b320-afe3-4140-94fc-675cb6ec1360.png">
  - A counter for counting region register/deregister, which helps us check whether we are observing all regions.
    <img width="343" alt="image" src="https://user-images.githubusercontent.com/36239017/164971523-e924087a-c658-4580-8893-8a0963a713aa.png">
  - A counter vector for summarizing the RocksDB statistics during initial scanning.
    <img width="1366" alt="image" src="https://user-images.githubusercontent.com/36239017/164971503-502d1474-5935-4ce7-a40b-762ab6399ea5.png">
  - A counter indicating whether the log backup endpoint has been enabled.
    <img width="277" alt="image" src="https://user-images.githubusercontent.com/36239017/164971474-89df3636-5911-40b5-bb48-b2edb0cb5555.png">
